### PR TITLE
fix purchase_requisition PO generation

### DIFF
--- a/stock_route_transit/data/stock_location.xml
+++ b/stock_route_transit/data/stock_location.xml
@@ -33,5 +33,12 @@
      <field name="route_id" ref="stock_dropshipping.route_drop_shipping"/>
    </record>
 
+   <record id="stock_dropshipping.picking_type_dropship" model="stock.picking.type">
+     <field name="name">Dropship</field>
+     <!-- this location is used by purchase_requisition as the destination of
+     the generated purchase orders -->
+     <field name="default_location_dest_id" ref="transit_outgoing"/>
+   </record>
+
   </data>
 </openerp>


### PR DESCRIPTION
the PO is generated with a location_id computed from the route
default_location_dest_id. For dropshipping we need this to be outgoing transit.
