### PR TITLE
[FIX] sale multi address: partner / delivery address

### DIFF
--- a/sale_transport_multi_address/model/sale_order.py
+++ b/sale_transport_multi_address/model/sale_order.py
@@ -69,6 +69,7 @@ class SaleOrder(models.Model):
         res = super(SaleOrder, self)._prepare_procurement_group(order)
         res.update({'consignee_id': order.consignee_id.id,
                     'delivery_address_id': order.partner_shipping_id.id,
+                    'partner_id': order.partner_id.id,
                     })
         return res
 

--- a/sale_transport_multi_address/tests/test_consignee_sale_order.py
+++ b/sale_transport_multi_address/tests/test_consignee_sale_order.py
@@ -27,12 +27,14 @@ class TestConsigneeSaleOrder(common.TransactionCase):
 
     def setUp(self):
         super(TestConsigneeSaleOrder, self).setUp()
-
         ref = self.env.ref
 
         part1 = ref('base.res_partner_1')
         part12 = ref('base.res_partner_12')
-
+        self.env['res.partner'].create(
+            {'name': 'part12 delivery',
+             'type': 'delivery',
+             'parent_id': part12.id})
         SO = self.env['sale.order']
         SOL = self.env['sale.order.line']
 
@@ -65,10 +67,14 @@ class TestConsigneeSaleOrder(common.TransactionCase):
         consignee is copied
 
         """
+        self.assertEquals(self.so.partner_shipping_id.parent_id,
+                          self.so.partner_id)
         self.so.signal_workflow('order_confirm')
         self.assertEquals(self.so.picking_ids.consignee_id,
                           self.so.consignee_id)
         self.assertEquals(self.so.picking_ids.origin_address_id,
                           self.so.company_id.partner_id)
         self.assertEquals(self.so.picking_ids.delivery_address_id,
+                          self.so.partner_shipping_id)
+        self.assertEquals(self.so.picking_ids.partner_id,
                           self.so.partner_id)

--- a/stock_transport_multi_address/model/stock.py
+++ b/stock_transport_multi_address/model/stock.py
@@ -45,7 +45,7 @@ class StockMove(models.Model):
             if not picking.consignee_id:
                 changes['consignee_id'] = group.consignee_id.id
             if not picking.delivery_address_id:
-                changes['delivery_address_id'] = group.partner_id.id
+                changes['delivery_address_id'] = group.delivery_address_id.id
             if not picking.origin_address_id:
                 # for the origin address, the information on the
                 # procurement.order trumps the information on the procurement


### PR DESCRIPTION
Don't have the partner of the generated picking be the delivery address of the sale order
(there is a delivery address field on thepicking for this)
