### PR TITLE
Add new modules for simplified transfer of goods between stock locations...

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,10 @@ Please don't hesitate to suggest one of your module to this project. Also, you m
  - https://github.com/OCA/stock-logistics-barcode
  - https://github.com/OCA/stock-logistics-warehouse
  - https://github.com/OCA/stock-logistics-workflow
+
+
+## Porting to v8
+
++ stock_internal_transfer / stock_internal_transfer_transit:
+Please check `stock_route_transit` before porting one of these modules to Odoo v8
+

--- a/stock_internal_transfer/__init__.py
+++ b/stock_internal_transfer/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_internal_transfer

--- a/stock_internal_transfer/__openerp__.py
+++ b/stock_internal_transfer/__openerp__.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#   Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+{
+    'name': 'Stock internal transfer',
+    'version': '1.0',
+    'category': '',
+    'summary': 'Wizard to simplify creation of internal stock transfers',
+    'description': """
+Wizard to simplify creation of internal transfers between stock locations.
+Creates stock moves and pickings to transfer selected goods between two
+stock locations.
+""",
+    'author': 'initOS GmbH & Co. KG',
+    'website': 'http://www.initos.com, Odoo Community Association (OCA)',
+    'depends': [
+        'stock',
+    ],
+    'data': [
+        'stock_internal_transfer_view.xml',
+    ],
+    'demo': [
+    ],
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+    'images': [
+    ],
+    'css': [
+    ],
+    'js': [
+    ],
+    'qweb': [
+    ],
+}

--- a/stock_internal_transfer/__openerp__.py
+++ b/stock_internal_transfer/__openerp__.py
@@ -28,8 +28,8 @@ Wizard to simplify creation of internal transfers between stock locations.
 Creates stock moves and pickings to transfer selected goods between two
 stock locations.
 """,
-    'author': 'initOS GmbH & Co. KG',
-    'website': 'http://www.initos.com, Odoo Community Association (OCA)',
+    'author': 'initOS GmbH & Co. KG, Odoo Community Association (OCA)',
+    'website': 'http://www.initos.com',
     'depends': [
         'stock',
     ],

--- a/stock_internal_transfer/i18n/de.po
+++ b/stock_internal_transfer/i18n/de.po
@@ -1,0 +1,119 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+# 	* stock_internal_transfer
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-04-23 16:52+0000\n"
+"PO-Revision-Date: 2015-04-23 18:53+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.5.4\n"
+
+#. module: stock_internal_transfer
+#: code:addons/stock_internal_transfer/stock_internal_transfer.py:57
+#, python-format
+msgid "Force Transfer"
+msgstr "Ausführung erzwingen"
+
+#. module: stock_internal_transfer
+#: field:stock.internal.transfer.line,product_id:0
+msgid "Product"
+msgstr "Produkt"
+
+#. module: stock_internal_transfer
+#: view:stock.internal.transfer:0
+msgid "or"
+msgstr "oder"
+
+#. module: stock_internal_transfer
+#: model:ir.actions.act_window,name:stock_internal_transfer.action_stock_interal_transfer_form
+#: model:ir.ui.menu,name:stock_internal_transfer.menu_stock_interal_transfer
+msgid "Create Internal Transfer"
+msgstr "Interne Lagerbewegung erstellen"
+
+#. module: stock_internal_transfer
+#: view:stock.internal.transfer:0
+msgid "Stock Internal Transfer"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: model:ir.model,name:stock_internal_transfer.model_stock_internal_transfer
+msgid "stock.internal.transfer"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: code:addons/stock_internal_transfer/stock_internal_transfer.py:57
+#, python-format
+msgid "Default"
+msgstr "Standard"
+
+#. module: stock_internal_transfer
+#: view:stock.internal.transfer:0
+msgid "Create Transfer"
+msgstr "Ausführen"
+
+#. module: stock_internal_transfer
+#: field:stock.internal.transfer.line,wizard_id:0
+msgid "Wizard"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: field:stock.internal.transfer,line_ids:0
+msgid "Move Lines"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: view:stock.internal.transfer:0
+msgid "Product Moves"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: code:addons/stock_internal_transfer/stock_internal_transfer.py:84
+#, python-format
+msgid "Internal Transfer Wizard"
+msgstr "Interne Lagerbewegung"
+
+#. module: stock_internal_transfer
+#: model:ir.model,name:stock_internal_transfer.model_stock_internal_transfer_line
+msgid "stock.internal.transfer.line"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: field:stock.internal.transfer,location_id:0
+msgid "Location"
+msgstr "Quelllager"
+
+#. module: stock_internal_transfer
+#: view:stock.internal.transfer:0
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#. module: stock_internal_transfer
+#: field:stock.internal.transfer,mode:0
+msgid "Transfer Mode"
+msgstr "Transfer Modus"
+
+#. module: stock_internal_transfer
+#: field:stock.internal.transfer,location_dest_id:0
+msgid "Dest. Location"
+msgstr "Ziellager"
+
+#. module: stock_internal_transfer
+#: field:stock.internal.transfer.line,product_uom:0
+msgid "Unit of Measure"
+msgstr "Mengeneinheit"
+
+#. module: stock_internal_transfer
+#: field:stock.internal.transfer.line,quantity:0
+msgid "Quantity"
+msgstr "Menge"
+
+#~ msgid "Delivery Address"
+#~ msgstr "Empfängeradresse"

--- a/stock_internal_transfer/i18n/stock_internal_transfer.pot
+++ b/stock_internal_transfer/i18n/stock_internal_transfer.pot
@@ -1,0 +1,116 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* stock_internal_transfer
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-04-23 16:52+0000\n"
+"PO-Revision-Date: 2015-04-23 16:52+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_internal_transfer
+#: code:addons/stock_internal_transfer/stock_internal_transfer.py:57
+#, python-format
+msgid "Force Transfer"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: field:stock.internal.transfer.line,product_id:0
+msgid "Product"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: view:stock.internal.transfer:0
+msgid "or"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: model:ir.actions.act_window,name:stock_internal_transfer.action_stock_interal_transfer_form
+#: model:ir.ui.menu,name:stock_internal_transfer.menu_stock_interal_transfer
+msgid "Create Internal Transfer"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: view:stock.internal.transfer:0
+msgid "Stock Internal Transfer"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: model:ir.model,name:stock_internal_transfer.model_stock_internal_transfer
+msgid "stock.internal.transfer"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: code:addons/stock_internal_transfer/stock_internal_transfer.py:57
+#, python-format
+msgid "Default"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: view:stock.internal.transfer:0
+msgid "Create Transfer"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: field:stock.internal.transfer.line,wizard_id:0
+msgid "Wizard"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: field:stock.internal.transfer,line_ids:0
+msgid "Move Lines"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: view:stock.internal.transfer:0
+msgid "Product Moves"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: code:addons/stock_internal_transfer/stock_internal_transfer.py:84
+#, python-format
+msgid "Internal Transfer Wizard"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: model:ir.model,name:stock_internal_transfer.model_stock_internal_transfer_line
+msgid "stock.internal.transfer.line"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: field:stock.internal.transfer,location_id:0
+msgid "Location"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: view:stock.internal.transfer:0
+msgid "Cancel"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: field:stock.internal.transfer,mode:0
+msgid "Transfer Mode"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: field:stock.internal.transfer,location_dest_id:0
+msgid "Dest. Location"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: field:stock.internal.transfer.line,product_uom:0
+msgid "Unit of Measure"
+msgstr ""
+
+#. module: stock_internal_transfer
+#: field:stock.internal.transfer.line,quantity:0
+msgid "Quantity"
+msgstr ""
+

--- a/stock_internal_transfer/stock_internal_transfer.py
+++ b/stock_internal_transfer/stock_internal_transfer.py
@@ -1,0 +1,162 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+from openerp.osv import orm, fields
+from openerp.netsvc import LocalService
+import openerp.addons.decimal_precision as dp
+from openerp.tools.translate import _
+
+
+class StockInternalTransferLine(orm.TransientModel):
+    _name = "stock.internal.transfer.line"
+    _rec_name = 'product_id'
+    _columns = {
+        'product_id': fields.many2one('product.product', string="Product",
+                                      required=True, ondelete='CASCADE'),
+        'quantity': fields.float(
+            "Quantity",
+            digits_compute=dp.get_precision('Product Unit of Measure'),
+            required=True),
+        'product_uom': fields.many2one('product.uom', 'Unit of Measure',
+                                       required=True, ondelete='CASCADE'),
+        'wizard_id': fields.many2one('stock.internal.transfer',
+                                     string="Wizard", ondelete='CASCADE'),
+    }
+
+    def onchange_product_id(self, cr, uid, ids, product_id, context=None):
+        uom_id = False
+        if product_id:
+            product = self.pool['product.product'].\
+                browse(cr, uid, product_id, context=context)
+            uom_id = product.uom_id.id
+        return {'value': {'product_uom': uom_id}}
+
+
+class StockInternalTransfer(orm.TransientModel):
+    _name = 'stock.internal.transfer'
+
+    def _get_transfer_mode_sel(self, cr, uid, context=None):
+        return [('default', _('Default')), ('force', _('Force Transfer'))]
+
+    _columns = {
+        'location_id': fields.many2one(
+            'stock.location', string="Location", required=True,
+            ondelete='CASCADE', domain=[('usage', '<>', 'view')]),
+        'location_dest_id': fields.many2one(
+            'stock.location', string="Dest. Location", required=True,
+            ondelete='CASCADE', domain=[('usage', '<>', 'view')]),
+        'line_ids': fields.one2many(
+            'stock.internal.transfer.line', 'wizard_id', 'Move Lines'),
+        'mode': fields.selection(
+            lambda self, *a, **kw:
+            self._get_transfer_mode_sel(*a, **kw), string="Transfer Mode", ),
+    }
+
+    _defaults = {
+        'mode': 'default',
+    }
+
+    def _prepare_picking(self, cr, uid, ids, context=None):
+        assert len(ids) == 1, \
+            'This function should only be used for a single id at a time.'
+
+        wiz = self.browse(cr, uid, ids[0], context=context)
+        picking_data = {
+            'type': 'internal',
+            'origin': _('Internal Transfer Wizard'),
+            'location_id': wiz.location_id.id,
+            'location_dest_id': wiz.location_dest_id.id,
+            'partner_id': wiz.location_dest_id.partner_id and
+            wiz.location_dest_id.partner_id.id or False,
+            # we require all products to be available for shipment
+            'move_type': 'one',
+        }
+        return picking_data
+
+    def _create_move_lines(self, cr, uid, ids, picking_id, context=None):
+        assert len(ids) == 1, \
+            'This function should only be used for a single id at a time.'
+        move_obj = self.pool['stock.move']
+        picking_model = self.pool['stock.picking']
+
+        wizard = self.browse(cr, uid, ids[0], context=context)
+        picking = picking_model.browse(cr, uid, picking_id, context=context)
+
+        for line in wizard.line_ids:
+            # todo move to _prepare function
+            move_data = {
+                'product_id': line.product_id.id,
+                'product_qty': line.quantity,
+                'product_uom': line.product_uom.id,
+                'picking_id': picking.id,
+                'location_id': picking.location_id.id,
+                'location_dest_id': picking.location_dest_id.id,
+                'name': line.product_id.name_get()[0][1],
+            }
+            move_obj.create(cr, uid, move_data, context=context)
+
+    def _create_transfer(self, cr, uid, ids, context=None):
+        assert len(ids) == 1, \
+            'This function should only be used for a single id at a time.'
+        picking_obj = self.pool['stock.picking']
+
+        picking_data = self._prepare_picking(cr, uid, ids, context=context)
+        picking_id = picking_obj.create(cr, uid, picking_data, context=context)
+        self._create_move_lines(cr, uid, ids, picking_id, context=context)
+
+        wf_service = LocalService("workflow")
+        wf_service.trg_validate(uid, 'stock.picking',
+                                picking_id, 'button_confirm', cr)
+        picking_id = [picking_id]
+        picking_obj.action_assign(cr, uid, picking_id)
+        return picking_id
+
+    def _trigger_workflow_for_delivery(self, cr, uid, ids, picking_ids,
+                                       context=None):
+        wf_service = LocalService("workflow")
+        for id in picking_ids:
+            wf_service.trg_validate(uid, 'stock.picking',
+                                    id, 'button_done', cr)
+
+    def _show_picking(self, picking_ids):
+        return {
+            'view_mode': 'form',
+            'view_id': False,
+            'view_type': 'form',
+            'res_id': picking_ids[0],
+            'res_model': 'stock.picking',
+            'type': 'ir.actions.act_window',
+            'target': 'current',
+        }
+
+    def create_transfer(self, cr, uid, ids, context=None):
+        assert len(ids) == 1, \
+            'This function should only be used for a single id at a time.'
+        wiz = self.browse(cr, uid, ids[0], context=context)
+        picking_obj = self.pool['stock.picking']
+
+        picking_ids = self._create_transfer(cr, uid, ids, context=context)
+        if wiz.mode in ['force']:
+            picking_obj.force_assign(cr, uid, picking_ids)
+            self._trigger_workflow_for_delivery(cr, uid, ids,
+                                                picking_ids, context=context)
+
+        return self._show_picking(picking_ids)

--- a/stock_internal_transfer/stock_internal_transfer.py
+++ b/stock_internal_transfer/stock_internal_transfer.py
@@ -59,10 +59,10 @@ class StockInternalTransfer(orm.TransientModel):
     _columns = {
         'location_id': fields.many2one(
             'stock.location', string="Location", required=True,
-            ondelete='CASCADE', domain=[('usage', '<>', 'view')]),
+            ondelete='CASCADE', domain=[('usage', '!=', 'view')]),
         'location_dest_id': fields.many2one(
             'stock.location', string="Dest. Location", required=True,
-            ondelete='CASCADE', domain=[('usage', '<>', 'view')]),
+            ondelete='CASCADE', domain=[('usage', '!=', 'view')]),
         'line_ids': fields.one2many(
             'stock.internal.transfer.line', 'wizard_id', 'Move Lines'),
         'mode': fields.selection(

--- a/stock_internal_transfer/stock_internal_transfer_view.xml
+++ b/stock_internal_transfer/stock_internal_transfer_view.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_stock_interal_transfer_form" model="ir.ui.view">
+            <field name="name">stock.internal.transfer.form</field>
+            <field name="model">stock.internal.transfer</field>
+            <field name="arch" type="xml">
+                <form string="Stock Internal Transfer" version="7.0">
+                    <sheet>
+                        <group>
+                            <field name="location_id"/>
+                            <field name="location_dest_id"/>
+                            <field name="mode"/>
+                        </group>
+                        <field name="line_ids">
+                            <tree editable="bottom" string="Product Moves">
+                                <field name="product_id" on_change="onchange_product_id(product_id)"/>
+                                <field name="quantity" />
+                                <field name="product_uom" groups="product.group_uom"/>
+                            </tree>
+                        </field>
+                    </sheet>
+                    <footer>
+                        <button name="create_transfer" string="Create Transfer" type="object" class="oe_highlight"/>
+                        or
+                        <button string="Cancel" class="oe_link" special="cancel" />
+                    </footer>
+                </form>
+             </field>
+         </record>
+
+         <record model="ir.actions.act_window" id="action_stock_interal_transfer_form">
+            <field name="name">Create Internal Transfer</field>
+            <field name="res_model">stock.internal.transfer</field>
+            <field name="view_mode">,form</field>
+            <field name="view_type">form</field>
+            <field name="view_id" ref="view_stock_interal_transfer_form"/>
+            <field name="target">new</field>
+        </record>
+
+        <menuitem id="menu_stock_interal_transfer"
+                  parent="stock.menu_stock_warehouse_mgmt"
+                  name="Create Internal Transfer"
+                  action="action_stock_interal_transfer_form"
+                  sequence="100"/>
+     </data>
+ </openerp>

--- a/stock_internal_transfer_transit/__init__.py
+++ b/stock_internal_transfer_transit/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_internal_transfer

--- a/stock_internal_transfer_transit/__openerp__.py
+++ b/stock_internal_transfer_transit/__openerp__.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+#   Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#   This program is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU Affero General Public License as
+#   published by the Free Software Foundation, either version 3 of the
+#   License, or (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU Affero General Public License for more details.
+#
+#   You should have received a copy of the GNU Affero General Public License
+#   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+###############################################################################
+
+{
+    'name': 'Stock internal transfer transit',
+    'version': '1.0',
+    'category': '',
+    'summary': "Process internal transfers using a dedicated stock location.",
+    'description': """
+Customize wizard from 'stock_internal_transfer' module to process internal
+transfers between stock locations using a dedicated 'transit' stock location.
+Each transfer creates two pickings and corresponding moves.
+First picking is to move goods from their source stock location into the
+transit stock location (truck, ship etc) for transport.
+Second picking is to move goods from transit stock location to
+destination stock location on arrival.
+""",
+    'author': 'initOS GmbH & Co. KG, Odoo Community Association (OCA)',
+    'website': 'http://www.initos.com',
+    'depends': [
+        'stock_internal_transfer',
+    ],
+    'data': [
+        'stock_transit.xml',
+    ],
+    'demo': [
+    ],
+    'installable': True,
+    'auto_install': False,
+    'application': False,
+    'images': [
+    ],
+    'css': [
+    ],
+    'js': [
+    ],
+    'qweb': [
+    ],
+}

--- a/stock_internal_transfer_transit/i18n/de.po
+++ b/stock_internal_transfer_transit/i18n/de.po
@@ -1,0 +1,27 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+# 	* stock_internal_transfer_transit
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2014-12-12 15:42+0000\n"
+"PO-Revision-Date: 2014-12-12 16:43+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 1.5.4\n"
+"Language: de\n"
+
+#. module: stock_internal_transfer_transit
+#: model:stock.location,name:stock_internal_transfer_transit.stock_location_transit
+msgid "Transit"
+msgstr "Lager für schwimmende Ware"
+
+#. module: stock_internal_transfer_transit
+#: model:ir.model,name:stock_internal_transfer_transit.model_stock_internal_transfer
+msgid "stock.internal.transfer"
+msgstr ""

--- a/stock_internal_transfer_transit/i18n/stock_internal_transfer_transit.pot
+++ b/stock_internal_transfer_transit/i18n/stock_internal_transfer_transit.pot
@@ -1,0 +1,27 @@
+# Translation of OpenERP Server.
+# This file contains the translation of the following modules:
+#	* stock_internal_transfer_transit
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenERP Server 7.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2015-04-23 16:52+0000\n"
+"PO-Revision-Date: 2015-04-23 16:52+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: stock_internal_transfer_transit
+#: model:stock.location,name:stock_internal_transfer_transit.stock_location_transit
+msgid "Transit"
+msgstr ""
+
+#. module: stock_internal_transfer_transit
+#: model:ir.model,name:stock_internal_transfer_transit.model_stock_internal_transfer
+msgid "stock.internal.transfer"
+msgstr ""
+

--- a/stock_internal_transfer_transit/stock_internal_transfer.py
+++ b/stock_internal_transfer_transit/stock_internal_transfer.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+##############################################################################
+#
+#    Copyright (C) 2014 initOS GmbH & Co. KG (<http://www.initos.com>).
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU Affero General Public License as
+#    published by the Free Software Foundation, either version 3 of the
+#    License, or (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+##############################################################################
+
+
+from openerp.osv import orm
+from openerp.netsvc import LocalService
+
+
+class StockInternalTransfer(orm.TransientModel):
+    _inherit = 'stock.internal.transfer'
+
+    def _prepare_picking(self, cr, uid, ids, context=None):
+        assert len(ids) == 1,\
+            'This function should only be used for a single id at a time.'
+
+        picking_data = super(StockInternalTransfer, self).\
+            _prepare_picking(cr, uid, ids, context=context)
+        wiz = self.browse(cr, uid, ids[0], context=context)
+
+        if wiz.mode == 'force':
+            return picking_data
+
+        # update destination location to transfer using
+        # intermediate transit stock location
+        model_data_obj = self.pool['ir.model.data']
+        stock_loc_transit_id = model_data_obj.\
+            get_object_reference(cr, uid, 'stock_internal_transfer_transit',
+                                 'stock_location_transit')[1]
+
+        picking_data.update({'location_dest_id': stock_loc_transit_id, })
+        return picking_data
+
+    def _show_picking(self, picking_ids):
+        act_data = super(StockInternalTransfer, self).\
+            _show_picking(picking_ids)
+        if 1 < len(picking_ids):
+            act_data.update({
+                'domain': [('id', 'in', picking_ids)],
+                'view_mode': 'tree,form',
+            })
+        return act_data
+
+    def _create_transfer(self, cr, uid, ids, context=None):
+        assert len(ids) == 1,\
+            'This function should only be used for a single id at a time.'
+        wiz = self.browse(cr, uid, ids[0], context=context)
+        picking_model = self.pool['stock.picking']
+
+        # create 1st picking: src loc -> transit loc
+        src2transit_id = super(StockInternalTransfer, self).\
+            _create_transfer(cr, uid, ids, context=context)[0]
+        src2transit = picking_model.\
+            browse(cr, uid, src2transit_id, context=context)
+
+        res_ids = [src2transit_id]
+
+        # check if transit loc is used in transfer
+        # create 2nd picking: transit loc -> dest loc
+        if wiz.location_dest_id.id != src2transit.location_dest_id.id:
+            picking_data = self._prepare_picking(cr, uid, ids, context=context)
+            picking_data.update({
+                'location_id': src2transit.location_dest_id.id,
+                'location_dest_id': wiz.location_dest_id.id,
+            })
+
+            transit2dst_id = picking_model.\
+                create(cr, uid, picking_data, context=context)
+            transit2dst = picking_model.\
+                browse(cr, uid, transit2dst_id, context=context)
+
+            move_obj = self.pool['stock.move']
+
+            for move in src2transit.move_lines:
+                new_id = move_obj.copy(cr, uid, move.id, {
+                    'location_id': transit2dst.location_id.id,
+                    'location_dest_id': transit2dst.location_dest_id.id,
+                    'picking_id': transit2dst.id,
+                    'state': 'waiting',
+                    'move_history_ids': [],
+                    'move_history_ids2': []}
+                )
+                # chain moves
+                move.write({
+                    'move_dest_id': new_id,
+                    'move_history_ids': [(4, new_id)]
+                })
+
+            wf_service = LocalService("workflow")
+            wf_service.trg_validate(uid, 'stock.picking',
+                                    transit2dst_id, 'button_confirm', cr)
+            res_ids.append(transit2dst_id)
+
+        return res_ids

--- a/stock_internal_transfer_transit/stock_transit.xml
+++ b/stock_internal_transfer_transit/stock_transit.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+        <record id="stock_location_transit" model="stock.location">
+            <field name="name">Transit</field>
+            <field name="location_id" ref="stock.stock_location_locations"/>
+            <field name="usage">internal</field>
+            <field name="company_id"></field>
+            <field name="comment">Stock location for goods in transfer between stock locations (i.e. on a truck or ship).</field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
Moved code here from https://github.com/OCA/stock-logistics-warehouse/pull/28 according to the discussion there. 

Prior description appended:

Add two new modules to ease creation of pickings and corresponding stock moves for transfer of goods between stock locations.
1. Wizard to select source and destination module and goods to transfer
2. Customization: Model the 
transfer of goods via a dedicated transit stock location (ship, truck etc.). This creates 2 separate pickings per transfer. One to move goods from source location to transit location and another one to receive goods from transit location into destination.

![bildschirmfoto vom 2014-12-12 17 40 37](https://cloud.githubusercontent.com/assets/1388003/5415235/0a204908-8226-11e4-9fb5-a59526bbcb43.png)....
