### PR TITLE
[FIX] stock_shipment_management

### DIFF
--- a/stock_shipment_management/model/shipment_plan.py
+++ b/stock_shipment_management/model/shipment_plan.py
@@ -96,7 +96,6 @@ class ShipmentPlan(models.Model):
         'res.partner',
         'To Address',
         readonly=True,  # updated by wizard
-        states={'draft': [('readonly', False)]},
         track_visibility='onchange',
         required=True,
     )


### PR DESCRIPTION
to_address_id must always be edited through the wizard

(missed this in #16)
