### PR TITLE
[FIX] purchase_transport_multi_address: Write on picking type onchange related usage field for changing field visibility

### DIFF
--- a/purchase_transport_multi_address/model/purchase_order.py
+++ b/purchase_transport_multi_address/model/purchase_order.py
@@ -82,6 +82,7 @@ class PurchaseOrder(models.Model):
             if pick_type.default_location_dest_id:
                 self.location_id = pick_type.default_location_dest_id
                 self.related_location_id = pick_type.default_location_dest_id
+                self.related_usage = pick_type.default_location_dest_id.usage
 
     @api.multi
     def onchange_partner_id(self, partner_id):


### PR DESCRIPTION
On runbot, if you change picking type to _Dropshipping_, delivery address is shown dynamically. This is because the visibility is linked to a field, related_usage, that is a related field, and it's updated also on the onchange. With the onchange overwriting, you have lost this update.
