### PR TITLE
Fix signal transit_end must be sent also when cancelling a move

### DIFF
--- a/stock_shipment_management/i18n/stock_shipment_management.pot
+++ b/stock_shipment_management/i18n/stock_shipment_management.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-06-11 11:34+0000\n"
-"PO-Revision-Date: 2015-06-11 11:34+0000\n"
+"POT-Creation-Date: 2015-07-16 09:17+0000\n"
+"PO-Revision-Date: 2015-07-16 09:17+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -808,6 +808,11 @@ msgstr ""
 #. module: stock_shipment_management
 #: field:shipment.plan,weight:0
 msgid "Weight"
+msgstr ""
+
+#: code:addons/stock_shipment_management/model/stock_move.py:127
+#, python-format
+msgid "You cannot cancel a shipment arrival stock move that depends on an uncancelled shipment departure stock move."
 msgstr ""
 
 #. module: stock_shipment_management

--- a/stock_shipment_management/model/stock_move.py
+++ b/stock_shipment_management/model/stock_move.py
@@ -110,7 +110,7 @@ class StockMove(models.Model):
     @api.multi
     def write(self, values):
         res = super(StockMove, self).write(values)
-        if values.get('state', '') == 'done':
+        if values.get('state', '') in ('done', 'cancel'):
             for ship in self.mapped('arrival_shipment_id'):
                 if ship.state == 'in_transit':
                     ship.signal_workflow('transit_end')


### PR DESCRIPTION
If some move are cancelled after all other have been done, we want to trigger the check as well to know if we can set shipment as Done
