### PR TITLE
[13.0][FIX] stock_location_address: compute must give a value to all records since v13.

### DIFF
--- a/stock_location_address/models/stock_location.py
+++ b/stock_location_address/models/stock_location.py
@@ -29,3 +29,5 @@ class StockLocation(models.Model):
                 record.real_address_id = record.address_id
             elif record.location_id:
                 record.real_address_id = record._get_parent_address()
+            else:
+                record.real_address_id = False


### PR DESCRIPTION
Otherwise we get the following error when creating new locations:

![image](https://user-images.githubusercontent.com/23449160/109957665-91c69e00-7ce5-11eb-8bb0-fc4098285214.png)

@ForgeFlow