### PR TITLE
[12.0][FIX] stock_location_address_purchase: Address was not passed when rules are used

### DIFF
--- a/stock_location_address_purchase/__manifest__.py
+++ b/stock_location_address_purchase/__manifest__.py
@@ -11,7 +11,7 @@
               'Odoo Community Association (OCA)',
     'category': 'Purchases',
     'depends': [
-        'purchase',
+        'purchase_stock',
         'stock_location_address',
     ],
     'installable': True,

--- a/stock_location_address_purchase/models/__init__.py
+++ b/stock_location_address_purchase/models/__init__.py
@@ -1,1 +1,2 @@
 from . import purchase
+from . import stock_rule

--- a/stock_location_address_purchase/models/stock_rule.py
+++ b/stock_location_address_purchase/models/stock_rule.py
@@ -1,0 +1,19 @@
+# Copyright 2021 Creu Blanca
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class StockRule(models.Model):
+
+    _inherit = 'stock.rule'
+
+    def _prepare_purchase_order(
+        self, product_id, product_qty, product_uom, origin, values, partner
+    ):
+        res = super()._prepare_purchase_order(
+            product_id, product_qty, product_uom, origin, values, partner)
+        location = self.picking_type_id.default_location_dest_id
+        if not res.get("dest_address_id", False) and location.usage == 'internal':
+            res["dest_address_id"] = location.real_address_id.id
+        return res

--- a/stock_location_address_purchase/tests/__init__.py
+++ b/stock_location_address_purchase/tests/__init__.py
@@ -1,1 +1,2 @@
 from . import test_purchase_address
+from . import test_purchase_buy_rule

--- a/stock_location_address_purchase/tests/test_purchase_buy_rule.py
+++ b/stock_location_address_purchase/tests/test_purchase_buy_rule.py
@@ -1,0 +1,37 @@
+from odoo.addons.purchase_stock.tests.common import TestPurchase
+from odoo import fields
+from datetime import timedelta
+
+
+class TestPurchaseBuyRule(TestPurchase):
+    def test_no_destination(self):
+        company = self.env.ref('base.main_company')
+        # Update company with Purchase Lead Time
+        company.write({'po_lead': 3.00})
+        date_planned = fields.Datetime.to_string(
+            fields.datetime.now() + timedelta(days=10)
+        )
+        self._create_make_procurement(
+            self.product_1, 15.00, date_planned=date_planned)
+        purchase = self.env['purchase.order.line'].search(
+            [('product_id', '=', self.product_1.id)], limit=1).order_id
+        self.assertTrue(purchase)
+        self.assertFalse(purchase.dest_address_id)
+
+    def test_destination(self):
+        company = self.env.ref('base.main_company')
+        # Update company with Purchase Lead Time
+        company.write({'po_lead': 3.00})
+        date_planned = fields.Datetime.to_string(
+            fields.datetime.now() + timedelta(days=10))
+        partner = self.env["res.partner"].create({
+            "name": "DEMO Partner"
+        })
+        self.warehouse_1.lot_stock_id.real_address_id = partner
+        self._create_make_procurement(
+            self.product_1, 15.00, date_planned=date_planned)
+        purchase = self.env['purchase.order.line'].search(
+            [('product_id', '=', self.product_1.id)], limit=1).order_id
+        self.assertTrue(purchase)
+        self.assertTrue(purchase.dest_address_id)
+        self.assertEqual(purchase.dest_address_id, partner)


### PR DESCRIPTION
When using procurement rules, the destination address is not correctly filled. This PR fixes the issue