### PR TITLE
[13.0][FIX] shipment_advice: fix creation from calendar

### DIFF
--- a/shipment_advice/views/shipment_advice.xml
+++ b/shipment_advice/views/shipment_advice.xml
@@ -309,6 +309,7 @@
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">shipment.advice</field>
         <field name="view_mode">calendar,tree,form</field>
+        <field name="context">{'default_name': '/'}</field>
     </record>
     <record
         id="shipment_advice_action_view_calendar"


### PR DESCRIPTION
The name field was not filled with its default value '/' when the
shipment was created from the calendar view.
Ensure we get the default value '/' in name field through the action.

Ref. 2660