### PR TITLE
[14.0][IMP] shipment_advice: test with normal stock user, increase coverage

### DIFF
--- a/shipment_advice/models/shipment_advice.py
+++ b/shipment_advice/models/shipment_advice.py
@@ -353,12 +353,14 @@ class ShipmentAdvice(models.Model):
             shipment.state = "draft"
 
     def button_open_planned_pickings(self):
-        action = self.env.ref("stock.action_picking_tree_all").read()[0]
+        action_xmlid = "stock.action_picking_tree_all"
+        action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
         action["domain"] = [("id", "in", self.planned_picking_ids.ids)]
         return action
 
     def button_open_planned_moves(self):
-        action = self.env.ref("stock.stock_move_action").read()[0]
+        action_xmlid = "stock.stock_move_action"
+        action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
         action["views"] = [
             (self.env.ref("stock.view_picking_move_tree").id, "tree"),
         ]
@@ -367,23 +369,27 @@ class ShipmentAdvice(models.Model):
         return action
 
     def button_open_loaded_pickings(self):
-        action = self.env.ref("stock.action_picking_tree_all").read()[0]
+        action_xmlid = "stock.action_picking_tree_all"
+        action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
         action["domain"] = [("id", "in", self.loaded_picking_ids.ids)]
         return action
 
     def button_open_loaded_move_lines(self):
-        action = self.env.ref("stock.stock_move_line_action").read()[0]
+        action_xmlid = "stock.stock_move_line_action"
+        action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
         action["domain"] = [("id", "in", self.loaded_move_line_without_package_ids.ids)]
         action["context"] = {}  # Disable filters
         return action
 
     def button_open_loaded_packages(self):
-        action = self.env.ref("stock.action_package_view").read()[0]
+        action_xmlid = "stock.action_package_view"
+        action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
         action["domain"] = [("id", "in", self.loaded_package_ids.ids)]
         return action
 
     def button_open_deliveries_in_progress(self):
-        action = self.env.ref("stock.action_picking_tree_all").read()[0]
+        action_xmlid = "stock.action_picking_tree_all"
+        action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
         view_tree = self.env.ref(
             "shipment_advice.stock_picking_loading_progress_view_tree"
         )
@@ -412,7 +418,8 @@ class ShipmentAdvice(models.Model):
         return action
 
     def button_open_receptions_in_progress(self):
-        action = self.env.ref("stock.action_picking_tree_all").read()[0]
+        action_xmlid = "stock.action_picking_tree_all"
+        action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
         view_tree = self.env.ref(
             "shipment_advice.stock_picking_loading_progress_view_tree"
         )

--- a/shipment_advice/models/stock_move_line.py
+++ b/shipment_advice/models/stock_move_line.py
@@ -16,9 +16,8 @@ class StockMoveLine(models.Model):
     )
 
     def button_load_in_shipment(self):
-        action = self.env.ref(
-            "shipment_advice.wizard_load_shipment_picking_action"
-        ).read()[0]
+        action_xmlid = "shipment_advice.wizard_load_shipment_picking_action"
+        action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
         action["context"] = {
             "active_model": self._name,
             "active_ids": self.ids,

--- a/shipment_advice/models/stock_package_level.py
+++ b/shipment_advice/models/stock_package_level.py
@@ -12,9 +12,8 @@ class StockPackageLevel(models.Model):
     package_weight_uom_name = fields.Char(related="package_id.weight_uom_name")
 
     def button_load_in_shipment(self):
-        action = self.env.ref(
-            "shipment_advice.wizard_load_shipment_picking_action"
-        ).read()[0]
+        action_xmlid = "shipment_advice.wizard_load_shipment_picking_action"
+        action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
         action["context"] = {
             "active_model": self._name,
             "active_ids": self.ids,

--- a/shipment_advice/models/stock_picking.py
+++ b/shipment_advice/models/stock_picking.py
@@ -166,23 +166,20 @@ class StockPicking(models.Model):
                 picking.loaded_progress = picking.loaded_move_lines_progress
 
     def button_plan_in_shipment(self):
-        action = self.env.ref(
-            "shipment_advice.wizard_plan_shipment_picking_action"
-        ).read()[0]
+        action_xmlid = "shipment_advice.wizard_plan_shipment_picking_action"
+        action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
         action["context"] = {"active_model": self._name, "active_ids": self.ids}
         return action
 
     def button_load_in_shipment(self):
-        action = self.env.ref(
-            "shipment_advice.wizard_load_shipment_picking_action"
-        ).read()[0]
+        action_xmlid = "shipment_advice.wizard_load_shipment_picking_action"
+        action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
         action["context"] = {"active_model": self._name, "active_ids": self.ids}
         return action
 
     def button_unload_from_shipment(self):
-        action = self.env.ref(
-            "shipment_advice.wizard_unload_shipment_picking_action"
-        ).read()[0]
+        action_xmlid = "shipment_advice.wizard_unload_shipment_picking_action"
+        action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
         action["context"] = {"active_model": self._name, "active_ids": self.ids}
         return action
 

--- a/shipment_advice/readme/CONTRIBUTORS.rst
+++ b/shipment_advice/readme/CONTRIBUTORS.rst
@@ -1,4 +1,6 @@
 * Sébastien Alix <sebastien.alix@camptocamp.com>
+* Guewen Baconnier <guewen.baconnier@camptocamp.com>
+* Simone Orsi <simahawk@gmail.com>
 * `Trobz <https://trobz.com>`_:
   * Dung Tran <dungtd@trobz.com>
 

--- a/shipment_advice/tests/__init__.py
+++ b/shipment_advice/tests/__init__.py
@@ -2,3 +2,4 @@ from . import test_shipment_advice
 from . import test_shipment_advice_plan
 from . import test_shipment_advice_load
 from . import test_shipment_advice_unload
+from . import test_shipment_advice_stock_user

--- a/shipment_advice/tests/test_shipment_advice_load.py
+++ b/shipment_advice/tests/test_shipment_advice_load.py
@@ -62,6 +62,9 @@ class TestShipmentAdviceLoad(Common):
             | self.move_product_out2.move_line_ids
             | self.move_product_out3.move_line_ids,
         )
+        lines = wiz.shipment_advice_id.loaded_move_line_ids
+        lines[1].result_package_id.shipping_weight = 10.0
+        self.assertEqual(wiz.shipment_advice_id.total_load, 10.0)
         self.assertEqual(len(wiz.shipment_advice_id.loaded_move_line_ids), 3)
         self.assertEqual(
             wiz.shipment_advice_id.loaded_move_lines_without_package_count, 1

--- a/shipment_advice/tests/test_shipment_advice_stock_user.py
+++ b/shipment_advice/tests/test_shipment_advice_stock_user.py
@@ -1,0 +1,89 @@
+# Copyright 2021 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from .common import Common
+
+
+class TestShipmentAdviceStockUser(Common):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.setUpClassUsers()
+
+    def test_shipment_advice_button_open_planned_pickings(self):
+        shipment_advice = self.shipment_advice_out.with_user(self.stock_user)
+        action = shipment_advice.button_open_planned_pickings()
+        self.assertEqual(action["name"], "Transfers")
+
+    def test_shipment_advice_button_open_planned_moves(self):
+        shipment_advice = self.shipment_advice_out.with_user(self.stock_user)
+        action = shipment_advice.button_open_planned_moves()
+        self.assertEqual(action["name"], "Stock Moves")
+
+    def test_shipment_advice_button_open_loaded_pickings(self):
+        shipment_advice = self.shipment_advice_out.with_user(self.stock_user)
+        action = shipment_advice.button_open_loaded_pickings()
+        self.assertEqual(action["name"], "Transfers")
+
+    def test_shipment_advice_button_open_loaded_move_lines(self):
+        shipment_advice = self.shipment_advice_out.with_user(self.stock_user)
+        action = shipment_advice.button_open_loaded_move_lines()
+        self.assertEqual(action["name"], "Product Moves")
+
+    def test_shipment_advice_button_open_loaded_packages(self):
+        shipment_advice = self.shipment_advice_out.with_user(self.stock_user)
+        action = shipment_advice.button_open_loaded_packages()
+        self.assertEqual(action["name"], "Packages")
+
+    def test_shipment_advice_button_open_deliveries_in_progress(self):
+        shipment_advice = self.shipment_advice_out.with_user(self.stock_user)
+        action = shipment_advice.button_open_deliveries_in_progress()
+        self.assertEqual(action["name"], "Transfers")
+
+    def test_shipment_advice_button_open_receptions_in_progress(self):
+        shipment_advice = self.shipment_advice_in.with_user(self.stock_user)
+        action = shipment_advice.button_open_receptions_in_progress()
+        self.assertEqual(action["name"], "Transfers")
+
+    def test_stock_move_line_button_load_in_shipment(self):
+        move_line = self.move_product_out1.move_line_ids[0]
+        action = move_line.with_user(self.stock_user).button_load_in_shipment()
+        self.assertEqual(action["name"], "Load in shipment")
+
+    def test_stock_picking_button_load_in_shipment(self):
+        move_line = self.move_product_out1.move_line_ids[0]
+        picking = move_line.picking_id.with_user(self.stock_user)
+        action = picking.button_load_in_shipment()
+        self.assertEqual(action["name"], "Load in shipment")
+
+    def test_stock_picking_button_plan_in_shipment(self):
+        move_line = self.move_product_out1.move_line_ids[0]
+        picking = move_line.picking_id.with_user(self.stock_user)
+        action = picking.button_plan_in_shipment()
+        self.assertEqual(action["name"], "Plan in shipment")
+
+    def test_stock_picking_button_unload_from_shipment(self):
+        move_line = self.move_product_out1.move_line_ids[0]
+        picking = move_line.picking_id.with_user(self.stock_user)
+        action = picking.button_unload_from_shipment()
+        self.assertEqual(action["name"], "Unload in shipment")
+
+    def test_stock_package_level_button_load_in_shipment(self):
+        package_level = self.move_product_out1.package_level_id
+        action = package_level.with_user(self.stock_user).button_load_in_shipment()
+        self.assertEqual(action["name"], "Load in shipment")
+
+    def test_wizard_plan_and_load_shipment(self):
+        move = self.move_product_out1
+        self._plan_records_in_shipment(
+            self.shipment_advice_out,
+            move,
+            user=self.stock_user,
+        )
+        self._in_progress_shipment_advice(self.shipment_advice_out)
+        wiz = self._load_records_in_shipment(
+            self.shipment_advice_out,
+            move.move_line_ids,
+            user=self.stock_user,
+        )
+        self.assertFalse(wiz.picking_ids)

--- a/shipment_advice/wizards/load_shipment.py
+++ b/shipment_advice/wizards/load_shipment.py
@@ -202,7 +202,8 @@ class WizardLoadInShipment(models.TransientModel):
             self.shipment_advice_id.action_in_progress()
         if self.open_shipment:
             view_form = self.env.ref("shipment_advice.shipment_advice_view_form")
-            action = self.env.ref("shipment_advice.shipment_advice_action").read()[0]
+            action_xmlid = "shipment_advice.shipment_advice_action"
+            action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
             del action["views"]
             action["res_id"] = self.shipment_advice_id.id
             action["view_id"] = view_form.id

--- a/shipment_advice/wizards/plan_shipment.py
+++ b/shipment_advice/wizards/plan_shipment.py
@@ -140,7 +140,8 @@ class WizardPlanShipment(models.TransientModel):
         self.picking_ids._plan_in_shipment(self.shipment_advice_id)
         self.move_ids._plan_in_shipment(self.shipment_advice_id)
         view_form = self.env.ref("shipment_advice.shipment_advice_view_form")
-        action = self.env.ref("shipment_advice.shipment_advice_action").sudo().read()[0]
+        action_xmlid = "shipment_advice.shipment_advice_action"
+        action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
         del action["views"]
         action["res_id"] = self.shipment_advice_id.id
         action["view_id"] = view_form.id


### PR DESCRIPTION
* When testing with `shopfloor_delivery_shipment` module, there was error in this module as below. That is because normal stock user is used in testing. So this commit is to add test with normal stock user to make sure UI works as expected.

```
odoo.exceptions.AccessError: You are not allowed to access 'Action Window' (ir.actions.act_window) records.

This operation is allowed for the following groups:
        - Administration/Settings

Contact your administrator to request access if necessary.
```
* This also increase coverage of `models/shipment_advice.py` a little bit.