### PR TITLE
[14][FIX] shipment_advice read action error

### DIFF
--- a/shipment_advice/wizards/plan_shipment.py
+++ b/shipment_advice/wizards/plan_shipment.py
@@ -140,7 +140,7 @@ class WizardPlanShipment(models.TransientModel):
         self.picking_ids._plan_in_shipment(self.shipment_advice_id)
         self.move_ids._plan_in_shipment(self.shipment_advice_id)
         view_form = self.env.ref("shipment_advice.shipment_advice_view_form")
-        action = self.env.ref("shipment_advice.shipment_advice_action").read()[0]
+        action = self.env.ref("shipment_advice.shipment_advice_action").sudo().read()[0]
         del action["views"]
         action["res_id"] = self.shipment_advice_id.id
         action["view_id"] = view_form.id


### PR DESCRIPTION
From the migration task, access to ir.actions.* needs sudo now...

https://github.com/OCA/maintainer-tools/wiki/Migration-to-version-14.0#tasks-to-do-in-the-migration