### PR TITLE
[13.0][FIX] shipment_advice: lock transfers during validation

### DIFF
--- a/shipment_advice/models/shipment_advice.py
+++ b/shipment_advice/models/shipment_advice.py
@@ -277,6 +277,11 @@ class ShipmentAdvice(models.Model):
             shipment.state = "in_progress"
         return True
 
+    def _lock_records(self, records):
+        """Lock records for the current SQL transaction."""
+        sql = "SELECT id FROM %s WHERE ID IN %%s FOR UPDATE" % records._table
+        self.env.cr.execute(sql, (tuple(records.ids),), log_exceptions=False)
+
     def action_done(self):
         wiz_model = self.env["stock.backorder.confirmation"]
         for shipment in self:
@@ -288,6 +293,7 @@ class ShipmentAdvice(models.Model):
                 )
             # Validate transfers (create backorders for unprocessed lines)
             if shipment.shipment_type == "incoming":
+                self._lock_records(self.planned_picking_ids)
                 for picking in self.planned_picking_ids:
                     if picking.state in ("cancel", "done"):
                         continue
@@ -301,8 +307,11 @@ class ShipmentAdvice(models.Model):
                 backorder_policy = (
                     shipment.company_id.shipment_advice_outgoing_backorder_policy
                 )
+                self._lock_records(self.loaded_picking_ids)
                 if backorder_policy == "create_backorder":
                     for picking in self.loaded_picking_ids:
+                        if picking.state in ("cancel", "done"):
+                            continue
                         if picking._check_backorder():
                             wiz = wiz_model.create({})
                             wiz.pick_ids = picking
@@ -311,6 +320,8 @@ class ShipmentAdvice(models.Model):
                             picking.action_done()
                 else:
                     for picking in self.loaded_picking_ids:
+                        if picking.state in ("cancel", "done"):
+                            continue
                         if not picking._check_backorder():
                             # no backorder needed means that all qty_done are
                             # set to fullfill the need => validate


### PR DESCRIPTION
If two shipment advices have loaded lines/packages from the same delivery, when we validate the shipments the `action_done` on the delivery is called twice (for instance), sending two times an email to the customer, adding two times delivery cost to the order, etc...

Perhaps a better fix would be to put the lock + check on the delivery state directly in the standard `stock_picking.action_done()` method... (would it be accepted by Odoo?)? For now we experienced this issue when dealing with the shipment advices.

Ref. 3017