### PR TITLE
[13.0] Revert "[FIX] shipment_advice: filter on current warehouse when listing deliveries to load"

### DIFF
--- a/shipment_advice/models/shipment_advice.py
+++ b/shipment_advice/models/shipment_advice.py
@@ -393,14 +393,10 @@ class ShipmentAdvice(models.Model):
         tree_view_index = action["views"].index((False, "tree"))
         action["views"][tree_view_index] = (view_tree.id, "tree")
         if self.planned_picking_ids:
-            action["domain"] = [
-                ("picking_type_id.warehouse_id", "=", self.warehouse_id.id),
-                ("id", "in", self.planned_picking_ids.ids),
-            ]
+            action["domain"] = [("id", "in", self.planned_picking_ids.ids)]
         else:
             domain = [
                 ("picking_type_id.code", "=", self.shipment_type),
-                ("picking_type_id.warehouse_id", "=", self.warehouse_id.id),
                 ("state", "=", "assigned"),
                 # Loaded in the current shipment or not loaded at all
                 "|",


### PR DESCRIPTION
This reverts commit b5e649c4ea405a771004f80c3768c83327d04895.

It doesn't suit the need for our customer... They are using a location which is somehow link to another warehouse but in the location tree of another warehouse.

DO NOT MERGE as we need to investigate first, maybe the rverted fix here is still good, but needs to be completed to fulfill our need.