### PR TITLE
[13.0][IMP] shipment_advice: handle multi warehouses

### DIFF
--- a/shipment_advice/models/shipment_advice.py
+++ b/shipment_advice/models/shipment_advice.py
@@ -9,7 +9,7 @@ class ShipmentAdvice(models.Model):
     _name = "shipment.advice"
     _inherit = ["mail.thread", "mail.activity.mixin"]
     _description = "Shipment Advice"
-    _order = "arrival_date asc, id desc"
+    _order = "arrival_date DESC, id DESC"
 
     def _default_warehouse_id(self):
         wh = self.env.ref("stock.warehouse0", raise_if_not_found=False)

--- a/shipment_advice/views/shipment_advice.xml
+++ b/shipment_advice/views/shipment_advice.xml
@@ -172,7 +172,10 @@
                             <field name="shipment_type" />
                         </group>
                         <group name="info2">
-                            <field name="dock_id" />
+                            <field
+                                name="dock_id"
+                                domain="[('warehouse_id', '=', warehouse_id)]"
+                            />
                             <field name="arrival_date" />
                             <field name="departure_date" />
                             <field name="ref" />

--- a/stock_dock/models/stock_dock.py
+++ b/stock_dock/models/stock_dock.py
@@ -11,3 +11,23 @@ class StockDock(models.Model):
     name = fields.Char(required=True)
     barcode = fields.Char()
     active = fields.Boolean(string="Active", default=True)
+    warehouse_id = fields.Many2one(
+        comodel_name="stock.warehouse",
+        ondelete="cascade",
+        string="Warehouse",
+        required=True,
+        check_company=True,
+        default=lambda self: self._default_warehouse_id(),
+    )
+    company_id = fields.Many2one(
+        comodel_name="res.company",
+        string="Company",
+        related="warehouse_id.company_id",
+        readonly=True,
+        store=True,
+        index=True,
+    )
+
+    def _default_warehouse_id(self):
+        wh = self.env.ref("stock.warehouse0", raise_if_not_found=False)
+        return wh.id or False

--- a/stock_dock/views/stock_dock.xml
+++ b/stock_dock/views/stock_dock.xml
@@ -18,9 +18,13 @@
                     <h1>
                         <field name="name" />
                     </h1>
-                    <label for="barcode" />
-                    <field name="barcode" />
                     <group name="info">
+                        <field
+                            name="warehouse_id"
+                            groups="stock.group_stock_multi_warehouses"
+                        />
+                        <field name="company_id" groups="base.group_multi_company" />
+                        <field name="barcode" />
                         <field name="active" invisible="1" />
                     </group>
                 </sheet>
@@ -31,10 +35,47 @@
         <field name="name">stock.dock.tree</field>
         <field name="model">stock.dock</field>
         <field name="arch" type="xml">
-            <tree string="Dock">
+            <tree string="Docks">
                 <field name="name" />
                 <field name="barcode" />
+                <field
+                    name="warehouse_id"
+                    groups="stock.group_stock_multi_warehouses"
+                />
+                <field name="company_id" groups="base.group_multi_company" />
             </tree>
+        </field>
+    </record>
+    <record id="stock_dock_view_search" model="ir.ui.view">
+        <field name="name">stock.dock.search</field>
+        <field name="model">stock.dock</field>
+        <field name="type">search</field>
+        <field name="arch" type="xml">
+            <search string="Docks">
+                <field name="name" />
+                <field name="barcode" />
+                <field name="company_id" groups="base.group_multi_company" />
+                <field name="warehouse_id" />
+                <filter
+                    string="Archived"
+                    name="inactive"
+                    domain="[('active','=',False)]"
+                />
+                <group expand="0" string="Group By">
+                    <filter
+                        string="Company"
+                        name="groupby_company_id"
+                        domain="[]"
+                        context="{'group_by': 'company_id'}"
+                    />
+                    <filter
+                        string="Warehouse"
+                        name="groupby_warehouse_id"
+                        domain="[]"
+                        context="{'group_by': 'warehouse_id'}"
+                    />
+                </group>
+            </search>
         </field>
     </record>
     <record id="stock_dock_action" model="ir.actions.act_window">


### PR DESCRIPTION
- bind docks to a warehouse
- add a hook in `shipment_advice` to customize the domain

This PR replaces https://github.com/OCA/stock-logistics-transport/pull/71 (so we keep the filter on current warehouse as it seems a sane default).

Ref. 3051