### PR TITLE
[14.0][FIX] stock_dock: Multi-company Issue

### DIFF
--- a/stock_dock/__manifest__.py
+++ b/stock_dock/__manifest__.py
@@ -4,12 +4,13 @@
 {
     "name": "Loading Dock",
     "summary": "Manage the loading docks of your warehouse.",
-    "version": "14.0.1.1.0",
+    "version": "14.0.2.1.0",
     "author": "Camptocamp, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-transport",
     "category": "Warehouse Management",
     "depends": ["stock"],
     "data": [
+        "data/data.xml",
         "security/ir.model.access.csv",
         "demo/stock_dock.xml",
         "views/stock_dock.xml",

--- a/stock_dock/data/data.xml
+++ b/stock_dock/data/data.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" ?>
+<odoo>
+    <record model="ir.rule" id="stock_dock">
+        <field name="name">stock.dock multi-company</field>
+        <field name="model_id" search="[('model','=','stock.dock')]" model="ir.model" />
+        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+    </record>
+</odoo>

--- a/stock_dock/models/stock_dock.py
+++ b/stock_dock/models/stock_dock.py
@@ -7,6 +7,7 @@ from odoo import fields, models
 class StockDock(models.Model):
     _name = "stock.dock"
     _description = "Dock, used by trucks to load/unload goods"
+    _check_company_auto = True
 
     name = fields.Char(required=True)
     barcode = fields.Char()
@@ -22,12 +23,11 @@ class StockDock(models.Model):
     company_id = fields.Many2one(
         comodel_name="res.company",
         string="Company",
-        related="warehouse_id.company_id",
-        readonly=True,
-        store=True,
-        index=True,
+        default=lambda self: self.env.company,
     )
 
     def _default_warehouse_id(self):
-        wh = self.env.ref("stock.warehouse0", raise_if_not_found=False)
+        wh = self.env["stock.warehouse"].search(
+            [("company_id", "=", self.env.company.id)]
+        )[0]
         return wh.id or False


### PR DESCRIPTION
The problem is that you can only select a WH of Company 1. 

This FIX allow to create a Dock using the WH of the self.env.company.

It add company ir.rules