### PR TITLE
[FIX] load in shipment advice: check only assigned move lines

### DIFF
--- a/shipment_advice/models/stock_move_line.py
+++ b/shipment_advice/models/stock_move_line.py
@@ -29,7 +29,9 @@ class StockMoveLine(models.Model):
         """Check that the lines represent whole packages (if applicable)."""
         for move_line in self:
             if move_line.package_level_id:
-                package_lines = move_line.package_level_id.move_line_ids
+                package_lines = move_line.package_level_id.move_line_ids.filtered(
+                    lambda l: l.state in ("partially_available", "assigned")
+                )
                 if not set(package_lines.ids).issubset(set(self.ids)):
                     return False
         return True

--- a/shipment_advice/tests/test_shipment_advice_load.py
+++ b/shipment_advice/tests/test_shipment_advice_load.py
@@ -149,3 +149,12 @@ class TestShipmentAdviceLoad(Common):
                 self.shipment_advice_out,
                 package_level,
             )
+
+    def test_load_check_package(self):
+        """load should ignore done and cancelled lines"""
+        move1lines = self.move_product_out1.move_line_ids
+        move2lines = self.move_product_out2.move_line_ids
+        picking = self.move_product_out1.picking_id
+        picking._put_in_pack(move1lines | move2lines)
+        self.move_product_out2._action_done()
+        move1lines._load_in_shipment(self.shipment_advice_out)


### PR DESCRIPTION
The package level groups the move lines moving quants from the same package. If one of the moves is manually delivered, the shipment advice will not proceed to load the remaining moves, as it considers that the entire package should be processed at the same time.

This PR enhances the error message to provide more information about the move line that is not accepted. Additionally, it modifies the package check to ignore move lines that are done or canceled.