### PR TITLE
[14.0][FIX] shipment_advice name creation

### DIFF
--- a/shipment_advice/models/shipment_advice.py
+++ b/shipment_advice/models/shipment_advice.py
@@ -52,7 +52,6 @@ class ShipmentAdvice(models.Model):
         string="Type",
         default="outgoing",
         required=True,
-        states={"draft": [("readonly", False)]},
         readonly=True,
         help="Use incoming to plan receptions, use outgoing for deliveries.",
     )
@@ -334,7 +333,7 @@ class ShipmentAdvice(models.Model):
     def create(self, vals):
         defaults = self.default_get(["name", "shipment_type"])
         sequence = self.env.ref("shipment_advice.shipment_advice_outgoing_sequence")
-        if defaults["shipment_type"] == "incoming":
+        if vals.get("shipment_type", defaults["shipment_type"]) == "incoming":
             sequence = self.env.ref("shipment_advice.shipment_advice_incoming_sequence")
         if vals.get("name", "/") == "/" and defaults.get("name", "/") == "/":
             vals["name"] = sequence.next_by_id()

--- a/shipment_advice/tests/test_shipment_advice.py
+++ b/shipment_advice/tests/test_shipment_advice.py
@@ -242,3 +242,7 @@ class TestShipmentAdvice(Common):
         self._cancel_shipment_advice(self.shipment_advice_out)
         self.shipment_advice_out.action_draft()
         self.assertEqual(self.shipment_advice_out.state, "draft")
+
+    def test_shipment_name(self):
+        self.assertTrue("OUT" in self.shipment_advice_out.name)
+        self.assertTrue("IN" in self.shipment_advice_in.name)

--- a/shipment_advice/views/shipment_advice.xml
+++ b/shipment_advice/views/shipment_advice.xml
@@ -183,7 +183,10 @@
                                 name="company_id"
                                 groups="base.group_multi_company"
                             />
-                            <field name="shipment_type" />
+                            <field
+                                name="shipment_type"
+                                attrs="{'readonly': [('name', '!=', '/')]}"
+                            />
                         </group>
                         <group name="info2">
                             <field


### PR DESCRIPTION
Before this fix an incoming shipment would not have the IN prefix or use the specific sequence for it.

Also, as the name is generated at record creation and the type of shipment is reflected in that name. Making the `shipment_type` readonly after creation makes more sense.