### PR TITLE
[16.0][IMP] Add default value to run_in_queue_job field

### DIFF
--- a/shipment_advice/models/shipment_advice.py
+++ b/shipment_advice/models/shipment_advice.py
@@ -175,8 +175,9 @@ class ShipmentAdvice(models.Model):
         ),
     )
     run_in_queue_job = fields.Boolean(
-        related="company_id.shipment_advice_run_in_queue_job"
+        default=lambda self: self._default_run_in_queue_job()
     )
+
     error_message = fields.Text(tracking=True)
 
     _sql_constraints = [
@@ -186,6 +187,9 @@ class ShipmentAdvice(models.Model):
             "Reference must be unique per company!",
         ),
     ]
+
+    def _default_run_in_queue_job(self):
+        return self.env.user.company_id.shipment_advice_run_in_queue_job
 
     def _check_include_package_level(self, package_level):
         """Check if a package level should be listed in the shipment advice.

--- a/shipment_advice/tests/test_shipment_advice_async.py
+++ b/shipment_advice/tests/test_shipment_advice_async.py
@@ -12,6 +12,8 @@ class TestShipmentAdvice(Common):
     def setUpClass(cls):
         super().setUpClass()
         cls.env.user.company_id.shipment_advice_run_in_queue_job = True
+        cls.shipment_advice_in.run_in_queue_job = True
+        cls.shipment_advice_out.run_in_queue_job = True
         cls.product_out4 = cls.env["product.product"].create(
             {"name": "product_out4", "type": "product"}
         )


### PR DESCRIPTION
We want run_in_queue_job to have a default value so that it does not always launches queue jobs as suggested by @sebalix [here](https://github.com/OCA/stock-logistics-transport/pull/114#discussion_r1474207213)
Also need to modify tests to work accordingly