### PR TITLE
[14.0][FIX] shipment_advice: do not copy shipment advice id on moves

### DIFF
--- a/shipment_advice/models/stock_move.py
+++ b/shipment_advice/models/stock_move.py
@@ -12,6 +12,7 @@ class StockMove(models.Model):
         ondelete="set null",
         string="Planned shipment",
         index=True,
+        copy=False,
     )
 
     def _plan_in_shipment(self, shipment_advice):

--- a/shipment_advice/models/stock_move.py
+++ b/shipment_advice/models/stock_move.py
@@ -24,3 +24,9 @@ class StockMove(models.Model):
         # Avoid having stock move assign to different shipment merged together
         res.append("shipment_advice_id")
         return res
+
+    def _prepare_move_split_vals(self, qty):
+        vals = super()._prepare_move_split_vals(qty)
+        if self.env.context.get("shipment_advice__propagate_on_split"):
+            vals.update(shipment_advice_id=self.shipment_advice_id.id)
+        return vals

--- a/shipment_advice/models/stock_move_line.py
+++ b/shipment_advice/models/stock_move_line.py
@@ -13,6 +13,7 @@ class StockMoveLine(models.Model):
         ondelete="set null",
         string="Shipment advice",
         index=True,
+        copy=False,
     )
 
     def button_load_in_shipment(self):

--- a/shipment_advice/tests/test_shipment_advice.py
+++ b/shipment_advice/tests/test_shipment_advice.py
@@ -266,3 +266,17 @@ class TestShipmentAdvice(Common):
             [("backorder_id", "=", picking.id)]
         )
         self.assertFalse(backorder_picking.move_lines.shipment_advice_id)
+
+    def test_move_split_propagation(self):
+        """Check the use of conext key to propagate the shipment id on move split."""
+        move = self.move_product_in1
+        self._plan_records_in_shipment(self.shipment_advice_in, move)
+        self.assertTrue(move.shipment_advice_id)
+        # Without the context key the shipment advice id is not copied
+        vals = move._prepare_move_split_vals(1)
+        self.assertTrue("shipemnt_advice_id" not in vals.keys())
+        # But it is with the context key
+        vals = move.with_context(
+            shipment_advice__propagate_on_split=True
+        )._prepare_move_split_vals(1)
+        self.assertTrue("shipment_advice_id" in vals.keys())


### PR DESCRIPTION
In the case of partially receiving goods, the backorder moves created should not be included in the shipment advice being processed. But it probably makes sense for outgoing move as well.