### PR TITLE
[14.0][IMP] shipment_advice: Autovalidate

### DIFF
--- a/shipment_advice/models/res_company.py
+++ b/shipment_advice/models/res_company.py
@@ -23,3 +23,6 @@ class ResCompany(models.Model):
             "deliveries will be shipped by several trucks."
         ),
     )
+    shipment_advice_auto_validate = fields.Boolean(
+        string="Shipment Advice: Auto Validate"
+    )

--- a/shipment_advice/models/res_config_settings.py
+++ b/shipment_advice/models/res_config_settings.py
@@ -10,3 +10,6 @@ class ResConfigSettings(models.TransientModel):
     shipment_advice_outgoing_backorder_policy = fields.Selection(
         related="company_id.shipment_advice_outgoing_backorder_policy", readonly=False
     )
+    shipment_advice_auto_validate = fields.Boolean(
+        related="company_id.shipment_advice_auto_validate", readonly=False
+    )

--- a/shipment_advice/models/stock_move.py
+++ b/shipment_advice/models/stock_move.py
@@ -12,6 +12,7 @@ class StockMove(models.Model):
         ondelete="set null",
         string="Planned shipment",
         index=True,
+        copy=False,
     )
 
     def _plan_in_shipment(self, shipment_advice):
@@ -22,4 +23,16 @@ class StockMove(models.Model):
         res = super()._prepare_merge_moves_distinct_fields()
         # Avoid having stock move assign to different shipment merged together
         res.append("shipment_advice_id")
+        return res
+
+    def _action_done(self, cancel_backorder=False):
+        res = super()._action_done(cancel_backorder=cancel_backorder)
+        shipment_advices = res.shipment_advice_id
+        for shipment_advice in shipment_advices:
+            if (
+                shipment_advice.shipment_type != "incoming"
+                or not shipment_advice.company_id.shipment_advice_auto_validate
+            ):
+                continue
+            shipment_advice.validate_when_fully_done()
         return res

--- a/shipment_advice/tests/common.py
+++ b/shipment_advice/tests/common.py
@@ -165,7 +165,7 @@ class Common(SavepointCase):
         return wiz
 
     def _load_records_in_shipment(self, shipment_advice, records, user=None):
-        """Load pickings, move lines or package levels in the givent shipment."""
+        """Load pickings, move lines or package levels in the given shipment."""
         wiz_model = self.env["wizard.load.shipment"].with_context(
             active_model=records._name,
             active_ids=records.ids,

--- a/shipment_advice/views/res_config_settings.xml
+++ b/shipment_advice/views/res_config_settings.xml
@@ -27,6 +27,17 @@
                         <field name="shipment_advice_outgoing_backorder_policy" />
                     </div>
                 </div>
+                <div class="col-12 col-lg-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field name="shipment_advice_auto_validate" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="shipment_advice_auto_validate" />
+                        <div class="text-muted">
+                            Validates shipment advice automatically whenever stock move is done
+                        </div>
+                    </div>
+                </div>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
- modified shipment_advice, so whenever we set stock move to done, and if autovalidate shipment advice is enabled in company settings - we set shipment advice to done
- updated tests, covered backorder.
