### PR TITLE
[14.0][IMP] shipment_advice: Unplan planned moves for incoming

### DIFF
--- a/shipment_advice/models/shipment_advice.py
+++ b/shipment_advice/models/shipment_advice.py
@@ -408,9 +408,9 @@ class ShipmentAdvice(models.Model):
             else:
                 picking._action_done()
 
-    def _unplan_loaded_moves(self):
+    def _unplan_planned_moves(self):
         """Unplan moves that were not loaded and validated"""
-        moves_to_unplan = self.loaded_move_line_ids.move_id.filtered(
+        moves_to_unplan = self.planned_move_ids.filtered(
             lambda m: m.state not in ("cancel", "done") and not m.quantity_done
         )
         moves_to_unplan.shipment_advice_id = False
@@ -426,8 +426,7 @@ class ShipmentAdvice(models.Model):
                     )
                 )
             shipment._close_pickings()
-            if shipment.shipment_type == "outgoing":
-                shipment._unplan_loaded_moves()
+            shipment._unplan_planned_moves()
             shipment_advice_ids_to_validate.append(shipment.id)
         if shipment_advice_ids_to_validate:
             self.browse(shipment_advice_ids_to_validate)._action_done()

--- a/shipment_advice_bill_auto_complete/models/shipment_advice.py
+++ b/shipment_advice_bill_auto_complete/models/shipment_advice.py
@@ -1,4 +1,5 @@
 # Copyright 2024 Camptocamp SA
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
 
 from odoo import api, fields, models
@@ -27,17 +28,13 @@ class ShipmentAdvice(models.Model):
         copy=False,
     )
 
-    @api.depends("planned_move_ids.purchase_line_id.order_id.partner_id")
+    @api.depends("planned_move_ids.picking_id.partner_id", "state", "shipment_type")
     def _compute_supplier_ids(self):
         for shipment in self:
-            if shipment.shipment_type != "incoming":
-                shipment.supplier_ids = False
-            elif shipment.state == "done":
-                shipment.supplier_ids = (
-                    shipment.loaded_move_line_ids.picking_id.partner_id
-                )
-            else:
-                shipment.supplier_ids = shipment.planned_move_ids.picking_id.partner_id
+            supplier_ids = False
+            if shipment.shipment_type == "incoming":
+                supplier_ids = shipment.planned_move_ids.picking_id.partner_id
+            shipment.supplier_ids = supplier_ids
 
     @api.depends("invoice_line_ids")
     def _compute_account_move_id(self):


### PR DESCRIPTION
If a shipment advice gets closed, no matter if it is outgoing or incoming.
There should be no open move linked to a closed advice. 