### PR TITLE
[16.0][IMP] Add default filter to loaded_move_line_without_package_ids

### DIFF
--- a/shipment_advice/views/shipment_advice.xml
+++ b/shipment_advice/views/shipment_advice.xml
@@ -212,6 +212,8 @@
                             <field
                                 name="loaded_move_line_without_package_ids"
                                 widget="many2many"
+                                context="{'search_default_incoming': True if shipment_type == 'incoming' else False,
+                                'search_default_outgoing': True if shipment_type == 'outgoing' else False}"
                             >
                                 <tree create="0">
                                     <field name="picking_id" />


### PR DESCRIPTION
Depending on the type of shipment advice, this sets an incoming or outgoing filter in the search pop up when clicking on "add a line" if a line is desired to be set manually from huge stock pickings.

This filter is not by domain but can be removed so no loss of functionality if somebody wants to load MO N-step transfers (why ?) or internal transfers from this list.

![image](https://github.com/user-attachments/assets/457c6e27-60f3-49dc-9bf2-daeaba724c34)