### PR TITLE
[16.0][IMP] shipment_advice_planner_toursolver: Recreate toursolver task

### DIFF
--- a/shipment_advice_planner_toursolver/tests/cassettes/TestShipmentAdvicePlannerToursolver.test_recreate_task.yaml
+++ b/shipment_advice_planner_toursolver/tests/cassettes/TestShipmentAdvicePlannerToursolver.test_recreate_task.yaml
@@ -1,0 +1,360 @@
+interactions:
+  - request:
+      body:
+        '{"simulationName": "TST/00000034", "countryCode": "US", "beginDate":
+        "2023-02-20", "language": "en_US", "depots": [{"x": 0.0, "y": 0.0, "id":
+        "dep_1"}], "orders": [{"customerId": false, "fixedVisitDuration": "00:03:00",
+        "id": 9, "label": "Wood Corner", "phone": "(623)-853-7197", "type": 0, "x": 0.0,
+        "y": 0.0, "customDataMap": {"address": "Wood Corner\n1839 Arbor Way\n\nTurlock
+        CA 95380\nUnited States"}, "timeWindows": [{"beginTime": "08:00", "endTime":
+        "17:00"}]}, {"customerId": false, "fixedVisitDuration": "00:03:00", "id": 31,
+        "label": "Gemini Furniture, Oscar Morgan", "phone": "(561)-239-1744", "type": 0,
+        "x": 0.0, "y": 0.0, "customDataMap": {"address": "Gemini Furniture\n317
+        Fairchild Dr\n\nFairfield CA 94535\nUnited States"}, "timeWindows":
+        [{"beginTime": "08:00", "endTime": "17:00"}]}], "resources": [{"id": "D1",
+        "mobileLogin": "d1@email.com", "openStart": false, "loadBeforeDeparture": true,
+        "noReload": true, "globalCapacity": 9999, "useAllCapacities": false, "startX":
+        0.0, "startY": 0.0, "endX": 0.0, "endY": 0.0, "workStartTime": "17:07:00",
+        "fixedLoadingDuration": "00:00:00", "travelPenalty": 0.0, "workPenalty": 0.0},
+        {"id": "D2", "mobileLogin": "d2@email.com", "openStart": false,
+        "loadBeforeDeparture": true, "noReload": true, "globalCapacity": 9999,
+        "useAllCapacities": false, "startX": 0.0, "startY": 0.0, "endX": 0.0, "endY":
+        0.0, "workStartTime": "17:07:00", "fixedLoadingDuration": "00:00:00",
+        "travelPenalty": 0.0, "workPenalty": 0.0}], "options": {"vehicleCode":
+        "deliveryIntermediateVehicle", "maxOptimDuration": "00:00:00",
+        "useForbiddenTransitAreas": false}}'
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "1596"
+        Content-Type:
+          - application/json
+        User-Agent:
+          - python-requests/2.28.2
+      method: POST
+      uri: https://geoservices.geoconcept.com/ToursolverCloud/api/ts/toursolver/optimize?tsCloudApiKey=fake_api_key
+    response:
+      body:
+        string: '{"message":null,"status":"OK","taskId":"7FFFFE79906B4288VjokZIK5TJSH0PH1Mlw77w"}'
+      headers:
+        Access-Control-Allow-Credentials:
+          - "true"
+        Access-Control-Allow-Headers:
+          - Accept,Upgrade-Insecure-Requests,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization
+        Access-Control-Allow-Methods:
+          - PUT, GET, POST, DELETE, PATCH, OPTIONS
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - "*,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization"
+        Access-Control-Max-Age:
+          - "1728000"
+        Connection:
+          - keep-alive
+        Content-Type:
+          - application/json;charset=UTF-8
+        Date:
+          - Mon, 20 Feb 2023 16:07:44 GMT
+        Set-Cookie:
+          - INGRESSTSPRODCOOKIE=1676909264.826.989.170065|526296c4243d90e279c23661c06665b2;
+            Path=/ToursolverCloud; Secure; HttpOnly; SameSite=None
+          - JSESSIONID=826AF2B934B2058F5B4FBAE8ABF1008F; Path=/ToursolverCloud;
+            HttpOnly; SameSite=None; Secure
+        Strict-Transport-Security:
+          - max-age=15724800; includeSubDomains
+        Transfer-Encoding:
+          - chunked
+        vary:
+          - origin
+      status:
+        code: 200
+        message: ""
+  - request:
+      body: null
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.28.2
+      method: GET
+      uri: https://geoservices.geoconcept.com/ToursolverCloud/api/ts/toursolver/status?taskId=7FFFFE79906B4288VjokZIK5TJSH0PH1Mlw77w&tsCloudApiKey=fake_api_key
+    response:
+      body:
+        string: '{"message":null,"status":"OK","optimizeStatus":"TERMINATED","startTime":1676909264236,"initialCost":1,"currentCost":1,"initialDriveDistance":0,"currentDriveDistance":0,"initialDriveTime":0,"currentDriveTime":0,"initialDriveCost":0,"currentDriveCost":0,"initialWorkTime":360,"currentWorkTime":360,"initialWorkCost":1,"currentWorkCost":1,"initialOverWorkTime":0,"currentOverWorkTime":0,"initialOverWorkCost":0,"currentOverWorkCost":0,"initialRestTime":0,"currentRestTime":0,"initialNightsCost":0,"currentNightsCost":0,"initialCourierCost":0,"currentCourierCost":0,"initialDeliveryCost":0,"currentDeliveryCost":0,"initialFixedCost":0,"currentFixedCost":0,"initialPickUpQuantity":0.0,"currentPickUpQuantity":0.0,"initialDeliveredQuantity":0.0,"currentDeliveredQuantity":0.0,"initialUnplannedVisits":0,"currentUnplannedVisits":0,"initialPlannedVisits":0,"currentPlannedVisits":0,"currentVisitsNb":2,"initialLateTime":1020,"currentLateTime":1020,"initialWaitTime":0,"currentWaitTime":0,"mileageChartRemainingTime":0,"initialCo2":0.0,"currentCo2":0.0,"initialOpenTourNumber":1,"currentOpenTourNumber":1,"subOptimNb":0,"subOptimWaitingNb":0,"subOptimRunningNb":0,"subOptimFinishedNb":0,"subOptimErrorNb":0,"subOptimAbortedNb":0,"simulationId":"7FFFFE79906B42C27iTIDFHlQT2UHxnPr7yFzg","positionInQueue":0}'
+      headers:
+        Access-Control-Allow-Credentials:
+          - "true"
+        Access-Control-Allow-Headers:
+          - Accept,Upgrade-Insecure-Requests,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization
+        Access-Control-Allow-Methods:
+          - PUT, GET, POST, DELETE, PATCH, OPTIONS
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - "*,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization"
+        Access-Control-Max-Age:
+          - "1728000"
+        Connection:
+          - keep-alive
+        Content-Type:
+          - application/json;charset=UTF-8
+        Date:
+          - Mon, 20 Feb 2023 16:08:45 GMT
+        Set-Cookie:
+          - INGRESSTSPRODCOOKIE=1676909326.021.7494.826478|526296c4243d90e279c23661c06665b2;
+            Path=/ToursolverCloud; Secure; HttpOnly; SameSite=None
+          - JSESSIONID=5235D2F23978EC9579570082D065639E; Path=/ToursolverCloud;
+            HttpOnly; SameSite=None; Secure
+        Strict-Transport-Security:
+          - max-age=15724800; includeSubDomains
+        Transfer-Encoding:
+          - chunked
+        vary:
+          - origin
+      status:
+        code: 200
+        message: ""
+  - request:
+      body: null
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.28.2
+      method: GET
+      uri: https://geoservices.geoconcept.com/ToursolverCloud/api/ts/toursolver/toursResult?taskId=7FFFFE79906B4288VjokZIK5TJSH0PH1Mlw77w&tsCloudApiKey=fake_api_key
+    response:
+      body:
+        string:
+          '{"message":null,"status":"OK","tours":[{"resourceId":"D2","travelDistance":12345,"travelDuration":"05:30","resourceCapacities":[ 12345.0,12345.0 ],"usedCapacities":[12345.0,12345.0],"deliveryCost":12345.0,"additionalCost":12345.0,"totalCost":12345.0,"reloadNb":12345,"plannedOrders":[{"resourceId":"D2","dayId":"1","stopId":"Start","stopPosition":0,"stopY":0.0,"stopX":0.0,"stopType":1,"stopDriveTime":"00:00","stopStartTime":"17:07","stopDuration":"00:00","stopStatus":0,"stopDriveDistance":0,"stopElapsedDistance":0,"placeName":null,"placeAddress":null,"aggregationInfo":null,"walkGoupRootId":null,"stopDriveSpeed":0.0},{"resourceId":"D2","dayId":"1","stopId":"Reload
+          (dep_1)","stopPosition":0,"stopY":0.0,"stopX":0.0,"stopType":4,"stopDriveTime":"00:00","stopStartTime":"17:07","stopDuration":"00:00","stopStatus":0,"stopDriveDistance":0,"stopElapsedDistance":0,"placeName":null,"placeAddress":null,"aggregationInfo":null,"walkGoupRootId":null,"stopDriveSpeed":0.0},{"resourceId":"D2","dayId":"1","stopId":"31","stopPosition":1,"stopY":0.0,"stopX":0.0,"stopType":0,"stopDriveTime":"00:00","stopStartTime":"17:07","stopDuration":"00:03","stopStatus":1,"stopDriveDistance":0,"stopElapsedDistance":0,"placeName":null,"placeAddress":null,"aggregationInfo":null,"walkGoupRootId":null,"stopDriveSpeed":0.0},{"resourceId":"D2","dayId":"1","stopId":"9","stopPosition":2,"stopY":0.0,"stopX":0.0,"stopType":0,"stopDriveTime":"00:00","stopStartTime":"17:10","stopDuration":"00:03","stopStatus":1,"stopDriveDistance":0,"stopElapsedDistance":0,"placeName":null,"placeAddress":null,"aggregationInfo":null,"walkGoupRootId":null,"stopDriveSpeed":0.0},{"resourceId":"D2","dayId":"1","stopId":"End","stopPosition":0,"stopY":0.0,"stopX":0.0,"stopType":2,"stopDriveTime":"00:00","stopStartTime":"17:13","stopDuration":"00:00","stopStatus":0,"stopDriveDistance":0,"stopElapsedDistance":0,"placeName":null,"placeAddress":null,"aggregationInfo":null,"walkGoupRootId":null,"stopDriveSpeed":0.0}]}],"unplannedOrders":[],"warnings":[{"objectType":"R","id":"D1","constraint":29,"constraintName":"WORKPENALTY","value":"0.0","message":"Journey
+          cost and hourly cost can not be set both to zero: default values will be
+          applied.","messageId":6,"i18nMessageCode":"missingMandatoryPenalties"},{"objectType":"R","id":"D2","constraint":29,"constraintName":"WORKPENALTY","value":"0.0","message":"Journey
+          cost and hourly cost can not be set both to zero: default values will be
+          applied.","messageId":6,"i18nMessageCode":"missingMandatoryPenalties"}],"taskId":"7FFFFE79906B4288VjokZIK5TJSH0PH1Mlw77w","simulationId":"7FFFFE79906B42C27iTIDFHlQT2UHxnPr7yFzg","inputData":null}'
+      headers:
+        Access-Control-Allow-Credentials:
+          - "true"
+        Access-Control-Allow-Headers:
+          - Accept,Upgrade-Insecure-Requests,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization
+        Access-Control-Allow-Methods:
+          - PUT, GET, POST, DELETE, PATCH, OPTIONS
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - "*,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization"
+        Access-Control-Max-Age:
+          - "1728000"
+        Connection:
+          - keep-alive
+        Content-Type:
+          - application/json;charset=UTF-8
+        Date:
+          - Mon, 20 Feb 2023 16:08:45 GMT
+        Set-Cookie:
+          - INGRESSTSPRODCOOKIE=1676909326.405.988.265846|526296c4243d90e279c23661c06665b2;
+            Path=/ToursolverCloud; Secure; HttpOnly; SameSite=None
+          - JSESSIONID=5740BF321B3908F767D7E5AAA120BD3C; Path=/ToursolverCloud;
+            HttpOnly; SameSite=None; Secure
+        Strict-Transport-Security:
+          - max-age=15724800; includeSubDomains
+        Transfer-Encoding:
+          - chunked
+        vary:
+          - origin
+      status:
+        code: 200
+        message: ""
+  - request:
+      body:
+        '{"simulationName": "TST/00000034", "countryCode": "US", "beginDate":
+        "2023-02-20", "language": "en_US", "depots": [{"x": 0.0, "y": 0.0, "id":
+        "dep_1"}], "orders": [{"customerId": false, "fixedVisitDuration": "00:03:00",
+        "id": 9, "label": "Wood Corner", "phone": "(623)-853-7197", "type": 0, "x": 0.0,
+        "y": 0.0, "customDataMap": {"address": "Wood Corner\n1839 Arbor Way\n\nTurlock
+        CA 95380\nUnited States"}, "timeWindows": [{"beginTime": "08:00", "endTime":
+        "17:00"}]}, {"customerId": false, "fixedVisitDuration": "00:03:00", "id": 31,
+        "label": "Gemini Furniture, Oscar Morgan", "phone": "(561)-239-1744", "type": 0,
+        "x": 0.0, "y": 0.0, "customDataMap": {"address": "Gemini Furniture\n317
+        Fairchild Dr\n\nFairfield CA 94535\nUnited States"}, "timeWindows":
+        [{"beginTime": "08:00", "endTime": "17:00"}]}], "resources": [{"id": "D1",
+        "mobileLogin": "d1@email.com", "openStart": false, "loadBeforeDeparture": true,
+        "noReload": true, "globalCapacity": 9999, "useAllCapacities": false, "startX":
+        0.0, "startY": 0.0, "endX": 0.0, "endY": 0.0, "workStartTime": "17:07:00",
+        "fixedLoadingDuration": "00:00:00", "travelPenalty": 0.0, "workPenalty": 0.0},
+        {"id": "D2", "mobileLogin": "d2@email.com", "openStart": false,
+        "loadBeforeDeparture": true, "noReload": true, "globalCapacity": 9999,
+        "useAllCapacities": false, "startX": 0.0, "startY": 0.0, "endX": 0.0, "endY":
+        0.0, "workStartTime": "17:07:00", "fixedLoadingDuration": "00:00:00",
+        "travelPenalty": 0.0, "workPenalty": 0.0}], "options": {"vehicleCode":
+        "deliveryIntermediateVehicle", "maxOptimDuration": "00:00:00",
+        "useForbiddenTransitAreas": false}}'
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        Content-Length:
+          - "1596"
+        Content-Type:
+          - application/json
+        User-Agent:
+          - python-requests/2.28.2
+      method: POST
+      uri: https://geoservices.geoconcept.com/ToursolverCloud/api/ts/toursolver/optimize?tsCloudApiKey=fake_api_key
+    response:
+      body:
+        string: '{"message":null,"status":"OK","taskId":"7FFFFE79906B4288VjokZIK5TJSH0PH1Mlw77w"}'
+      headers:
+        Access-Control-Allow-Credentials:
+          - "true"
+        Access-Control-Allow-Headers:
+          - Accept,Upgrade-Insecure-Requests,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization
+        Access-Control-Allow-Methods:
+          - PUT, GET, POST, DELETE, PATCH, OPTIONS
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - "*,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization"
+        Access-Control-Max-Age:
+          - "1728000"
+        Connection:
+          - keep-alive
+        Content-Type:
+          - application/json;charset=UTF-8
+        Date:
+          - Mon, 20 Feb 2023 16:07:44 GMT
+        Set-Cookie:
+          - INGRESSTSPRODCOOKIE=1676909264.826.989.170065|526296c4243d90e279c23661c06665b2;
+            Path=/ToursolverCloud; Secure; HttpOnly; SameSite=None
+          - JSESSIONID=826AF2B934B2058F5B4FBAE8ABF1008F; Path=/ToursolverCloud;
+            HttpOnly; SameSite=None; Secure
+        Strict-Transport-Security:
+          - max-age=15724800; includeSubDomains
+        Transfer-Encoding:
+          - chunked
+        vary:
+          - origin
+      status:
+        code: 200
+        message: ""
+  - request:
+      body: null
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.28.2
+      method: GET
+      uri: https://geoservices.geoconcept.com/ToursolverCloud/api/ts/toursolver/status?taskId=7FFFFE79906B4288VjokZIK5TJSH0PH1Mlw77w&tsCloudApiKey=fake_api_key
+    response:
+      body:
+        string: '{"message":null,"status":"OK","optimizeStatus":"TERMINATED","startTime":1676909264236,"initialCost":1,"currentCost":1,"initialDriveDistance":0,"currentDriveDistance":0,"initialDriveTime":0,"currentDriveTime":0,"initialDriveCost":0,"currentDriveCost":0,"initialWorkTime":360,"currentWorkTime":360,"initialWorkCost":1,"currentWorkCost":1,"initialOverWorkTime":0,"currentOverWorkTime":0,"initialOverWorkCost":0,"currentOverWorkCost":0,"initialRestTime":0,"currentRestTime":0,"initialNightsCost":0,"currentNightsCost":0,"initialCourierCost":0,"currentCourierCost":0,"initialDeliveryCost":0,"currentDeliveryCost":0,"initialFixedCost":0,"currentFixedCost":0,"initialPickUpQuantity":0.0,"currentPickUpQuantity":0.0,"initialDeliveredQuantity":0.0,"currentDeliveredQuantity":0.0,"initialUnplannedVisits":0,"currentUnplannedVisits":0,"initialPlannedVisits":0,"currentPlannedVisits":0,"currentVisitsNb":2,"initialLateTime":1020,"currentLateTime":1020,"initialWaitTime":0,"currentWaitTime":0,"mileageChartRemainingTime":0,"initialCo2":0.0,"currentCo2":0.0,"initialOpenTourNumber":1,"currentOpenTourNumber":1,"subOptimNb":0,"subOptimWaitingNb":0,"subOptimRunningNb":0,"subOptimFinishedNb":0,"subOptimErrorNb":0,"subOptimAbortedNb":0,"simulationId":"7FFFFE79906B42C27iTIDFHlQT2UHxnPr7yFzg","positionInQueue":0}'
+      headers:
+        Access-Control-Allow-Credentials:
+          - "true"
+        Access-Control-Allow-Headers:
+          - Accept,Upgrade-Insecure-Requests,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization
+        Access-Control-Allow-Methods:
+          - PUT, GET, POST, DELETE, PATCH, OPTIONS
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - "*,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization"
+        Access-Control-Max-Age:
+          - "1728000"
+        Connection:
+          - keep-alive
+        Content-Type:
+          - application/json;charset=UTF-8
+        Date:
+          - Mon, 20 Feb 2023 16:08:45 GMT
+        Set-Cookie:
+          - INGRESSTSPRODCOOKIE=1676909326.021.7494.826478|526296c4243d90e279c23661c06665b2;
+            Path=/ToursolverCloud; Secure; HttpOnly; SameSite=None
+          - JSESSIONID=5235D2F23978EC9579570082D065639E; Path=/ToursolverCloud;
+            HttpOnly; SameSite=None; Secure
+        Strict-Transport-Security:
+          - max-age=15724800; includeSubDomains
+        Transfer-Encoding:
+          - chunked
+        vary:
+          - origin
+      status:
+        code: 200
+        message: ""
+  - request:
+      body: null
+      headers:
+        Accept:
+          - application/json
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.28.2
+      method: GET
+      uri: https://geoservices.geoconcept.com/ToursolverCloud/api/ts/toursolver/toursResult?taskId=7FFFFE79906B4288VjokZIK5TJSH0PH1Mlw77w&tsCloudApiKey=fake_api_key
+    response:
+      body:
+        string:
+          '{"message":null,"status":"OK","tours":[{"resourceId":"D2","travelDistance":12345,"travelDuration":"05:30","resourceCapacities":[ 12345.0,12345.0 ],"usedCapacities":[12345.0,12345.0],"deliveryCost":12345.0,"additionalCost":12345.0,"totalCost":12345.0,"reloadNb":12345,"plannedOrders":[{"resourceId":"D2","dayId":"1","stopId":"Start","stopPosition":0,"stopY":0.0,"stopX":0.0,"stopType":1,"stopDriveTime":"00:00","stopStartTime":"17:07","stopDuration":"00:00","stopStatus":0,"stopDriveDistance":0,"stopElapsedDistance":0,"placeName":null,"placeAddress":null,"aggregationInfo":null,"walkGoupRootId":null,"stopDriveSpeed":0.0},{"resourceId":"D2","dayId":"1","stopId":"Reload
+          (dep_1)","stopPosition":0,"stopY":0.0,"stopX":0.0,"stopType":4,"stopDriveTime":"00:00","stopStartTime":"17:07","stopDuration":"00:00","stopStatus":0,"stopDriveDistance":0,"stopElapsedDistance":0,"placeName":null,"placeAddress":null,"aggregationInfo":null,"walkGoupRootId":null,"stopDriveSpeed":0.0},{"resourceId":"D2","dayId":"1","stopId":"31","stopPosition":1,"stopY":0.0,"stopX":0.0,"stopType":0,"stopDriveTime":"00:00","stopStartTime":"17:07","stopDuration":"00:03","stopStatus":1,"stopDriveDistance":0,"stopElapsedDistance":0,"placeName":null,"placeAddress":null,"aggregationInfo":null,"walkGoupRootId":null,"stopDriveSpeed":0.0},{"resourceId":"D2","dayId":"1","stopId":"9","stopPosition":2,"stopY":0.0,"stopX":0.0,"stopType":0,"stopDriveTime":"00:00","stopStartTime":"17:10","stopDuration":"00:03","stopStatus":1,"stopDriveDistance":0,"stopElapsedDistance":0,"placeName":null,"placeAddress":null,"aggregationInfo":null,"walkGoupRootId":null,"stopDriveSpeed":0.0},{"resourceId":"D2","dayId":"1","stopId":"End","stopPosition":0,"stopY":0.0,"stopX":0.0,"stopType":2,"stopDriveTime":"00:00","stopStartTime":"17:13","stopDuration":"00:00","stopStatus":0,"stopDriveDistance":0,"stopElapsedDistance":0,"placeName":null,"placeAddress":null,"aggregationInfo":null,"walkGoupRootId":null,"stopDriveSpeed":0.0}]}],"unplannedOrders":[],"warnings":[{"objectType":"R","id":"D1","constraint":29,"constraintName":"WORKPENALTY","value":"0.0","message":"Journey
+          cost and hourly cost can not be set both to zero: default values will be
+          applied.","messageId":6,"i18nMessageCode":"missingMandatoryPenalties"},{"objectType":"R","id":"D2","constraint":29,"constraintName":"WORKPENALTY","value":"0.0","message":"Journey
+          cost and hourly cost can not be set both to zero: default values will be
+          applied.","messageId":6,"i18nMessageCode":"missingMandatoryPenalties"}],"taskId":"7FFFFE79906B4288VjokZIK5TJSH0PH1Mlw77w","simulationId":"7FFFFE79906B42C27iTIDFHlQT2UHxnPr7yFzg","inputData":null}'
+      headers:
+        Access-Control-Allow-Credentials:
+          - "true"
+        Access-Control-Allow-Headers:
+          - Accept,Upgrade-Insecure-Requests,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization
+        Access-Control-Allow-Methods:
+          - PUT, GET, POST, DELETE, PATCH, OPTIONS
+        Access-Control-Allow-Origin:
+          - "*"
+        Access-Control-Expose-Headers:
+          - "*,Origin,DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Authorization"
+        Access-Control-Max-Age:
+          - "1728000"
+        Connection:
+          - keep-alive
+        Content-Type:
+          - application/json;charset=UTF-8
+        Date:
+          - Mon, 20 Feb 2023 16:08:45 GMT
+        Set-Cookie:
+          - INGRESSTSPRODCOOKIE=1676909326.405.988.265846|526296c4243d90e279c23661c06665b2;
+            Path=/ToursolverCloud; Secure; HttpOnly; SameSite=None
+          - JSESSIONID=5740BF321B3908F767D7E5AAA120BD3C; Path=/ToursolverCloud;
+            HttpOnly; SameSite=None; Secure
+        Strict-Transport-Security:
+          - max-age=15724800; includeSubDomains
+        Transfer-Encoding:
+          - chunked
+        vary:
+          - origin
+      status:
+        code: 200
+        message: ""
+version: 1

--- a/shipment_advice_planner_toursolver/views/shipment_advice.xml
+++ b/shipment_advice_planner_toursolver/views/shipment_advice.xml
@@ -7,6 +7,15 @@
         <field name="model">shipment.advice</field>
         <field name="inherit_id" ref="shipment_advice.shipment_advice_view_form" />
         <field name="arch" type="xml">
+            <header position="inside">
+                <field name="is_create_toursolver_task_allowed" invisible="1" />
+                    <button
+                    name="create_toursolver_task"
+                    type="object"
+                    string="Create TourSolver Task"
+                    attrs="{'invisible': [('is_create_toursolver_task_allowed', '=', False)]}"
+                />
+            </header>
             <page name="carriers" position="after">
                 <page name="toursolver" string="Toursolver">
                     <group>


### PR DESCRIPTION
It may happen that the shipment advice is created after the toursolver task is completed, and the user decides to add a picking to it. It's easier to have an action on the shipment advice to recreate the toursolver task without going through the planner again.

As a safeguard, we do not allow this action unless the previous task has been removed. When the task is recreated, the new task will not generate a new shipment advice but will be assigned to the existing one.