### PR TITLE
[16.0][FW] shipment_advice: multiple ports from 14.0

### DIFF
--- a/shipment_advice/models/res_company.py
+++ b/shipment_advice/models/res_company.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Camptocamp SA
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import fields, models
@@ -28,4 +29,12 @@ class ResCompany(models.Model):
         help="To prevent timeouts for large shipments, enable this option to execute "
         "shipment advice validation through a queued jobs. Each picking will be "
         "validated in a separate job.",
+    )
+    shipment_advice_auto_close_incoming = fields.Boolean(
+        string="Shipment Advice: Auto Close Incoming Advices",
+        help=(
+            "This flag indicates if an incoming shipment advice "
+            "will be automatically set to done "
+            "if all related moves are done or canceled"
+        ),
     )

--- a/shipment_advice/models/res_config_settings.py
+++ b/shipment_advice/models/res_config_settings.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Camptocamp SA
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import fields, models
@@ -12,4 +13,7 @@ class ResConfigSettings(models.TransientModel):
     )
     shipment_advice_run_in_queue_job = fields.Boolean(
         related="company_id.shipment_advice_run_in_queue_job", readonly=False
+    )
+    shipment_advice_auto_close_incoming = fields.Boolean(
+        related="company_id.shipment_advice_auto_close_incoming", readonly=False
     )

--- a/shipment_advice/models/shipment_advice.py
+++ b/shipment_advice/models/shipment_advice.py
@@ -58,7 +58,6 @@ class ShipmentAdvice(models.Model):
         string="Type",
         default="outgoing",
         required=True,
-        states={"draft": [("readonly", False)]},
         readonly=True,
         help="Use incoming to plan receptions, use outgoing for deliveries.",
     )
@@ -254,7 +253,7 @@ class ShipmentAdvice(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        defaults = self.default_get(["name"])
+        defaults = self.default_get(["name", "shipment_type"])
         outgoing_sequence = self.env.ref(
             "shipment_advice.shipment_advice_outgoing_sequence"
         )
@@ -263,7 +262,7 @@ class ShipmentAdvice(models.Model):
         )
         for vals in vals_list:
             sequence = outgoing_sequence
-            if vals["shipment_type"] == "incoming":
+            if vals.get("shipment_type", defaults["shipment_type"]) == "incoming":
                 sequence = incomig_sequence
             if vals.get("name", "/") == "/" and defaults.get("name", "/") == "/":
                 vals["name"] = sequence.next_by_id()

--- a/shipment_advice/models/stock_move.py
+++ b/shipment_advice/models/stock_move.py
@@ -18,3 +18,9 @@ class StockMove(models.Model):
     def _plan_in_shipment(self, shipment_advice):
         """Plan the moves into the given shipment advice."""
         self.shipment_advice_id = shipment_advice
+
+    def _prepare_merge_moves_distinct_fields(self):
+        res = super()._prepare_merge_moves_distinct_fields()
+        # Avoid having stock move assign to different shipment merged together
+        res.append("shipment_advice_id")
+        return res

--- a/shipment_advice/models/stock_move.py
+++ b/shipment_advice/models/stock_move.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Camptocamp SA
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import fields, models
@@ -23,4 +24,14 @@ class StockMove(models.Model):
         res = super()._prepare_merge_moves_distinct_fields()
         # Avoid having stock move assign to different shipment merged together
         res.append("shipment_advice_id")
+        return res
+
+    def _action_done(self, cancel_backorder=False):
+        res = super()._action_done(cancel_backorder=cancel_backorder)
+        res.shipment_advice_id.auto_close_incoming_shipment_advices()
+        return res
+
+    def _action_cancel(self):
+        res = super()._action_cancel()
+        self.shipment_advice_id.auto_close_incoming_shipment_advices()
         return res

--- a/shipment_advice/models/stock_picking.py
+++ b/shipment_advice/models/stock_picking.py
@@ -68,6 +68,9 @@ class StockPicking(models.Model):
         "shipment.advice",
         compute="_compute_loaded_in_shipment",
     )
+    loaded_waiting_quantity = fields.Float(
+        "Waiting Quantity", compute="_compute_shipment_loaded_progress"
+    )
 
     @api.depends("move_line_ids.shipment_advice_id")
     def _compute_loaded_in_shipment(self):
@@ -157,6 +160,12 @@ class StockPicking(models.Model):
                 picking.loaded_weight_progress = (
                     f"{picking.loaded_weight} / {total_weight}"
                 )
+            waiting_moves = picking.move_ids.filtered(
+                lambda ml: ml.state not in ["done", "cancel"]
+            )
+            picking.loaded_waiting_quantity = sum(
+                waiting_moves.mapped("product_qty")
+            ) - sum(waiting_moves.mapped("reserved_availability"))
             # Overall progress based on the operation type
             if picking.picking_type_id.show_entire_packs:
                 picking.loaded_progress_f = picking.loaded_packages_progress_f

--- a/shipment_advice/readme/CONTRIBUTORS.rst
+++ b/shipment_advice/readme/CONTRIBUTORS.rst
@@ -3,6 +3,7 @@
 * Simone Orsi <simahawk@gmail.com>
 * `Trobz <https://trobz.com>`_:
   * Dung Tran <dungtd@trobz.com>
+* Michael Tietz (MT Software) <mtietz@mt-software.de>
 
 Design
 ~~~~~~

--- a/shipment_advice/tests/__init__.py
+++ b/shipment_advice/tests/__init__.py
@@ -5,3 +5,4 @@ from . import test_shipment_advice_load
 from . import test_shipment_advice_picking_values
 from . import test_shipment_advice_unload
 from . import test_shipment_advice_stock_user
+from . import test_shipment_advice_auto_close

--- a/shipment_advice/tests/__init__.py
+++ b/shipment_advice/tests/__init__.py
@@ -2,5 +2,6 @@ from . import test_shipment_advice
 from . import test_shipment_advice_async
 from . import test_shipment_advice_plan
 from . import test_shipment_advice_load
+from . import test_shipment_advice_picking_values
 from . import test_shipment_advice_unload
 from . import test_shipment_advice_stock_user

--- a/shipment_advice/tests/common.py
+++ b/shipment_advice/tests/common.py
@@ -1,4 +1,5 @@
 # Copyright 2021 Camptocamp SA
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import fields
@@ -124,30 +125,33 @@ class Common(TransactionCase):
         else:
             self.assertIn("IN", shipment_advice.name)
 
-    def _confirm_shipment_advice(self, shipment_advice, arrival_date=None):
+    @classmethod
+    def confirm_shipment_advice(cls, shipment_advice, arrival_date=None):
         if shipment_advice.state != "draft":
             return
         if arrival_date is None:
             arrival_date = fields.Datetime.now()
         shipment_advice.arrival_date = arrival_date
         shipment_advice.action_confirm()
-        self.assertEqual(shipment_advice.state, "confirmed")
 
-    def _in_progress_shipment_advice(self, shipment_advice, dock=None):
-        self._confirm_shipment_advice(shipment_advice)
+    @classmethod
+    def progress_shipment_advice(cls, shipment_advice, dock=None):
+        cls.confirm_shipment_advice(shipment_advice)
         if shipment_advice.state != "confirmed":
             return
-        shipment_advice.dock_id = dock or self.dock
+        shipment_advice.dock_id = dock or cls.dock
         shipment_advice.action_in_progress()
-        self.assertEqual(shipment_advice.state, "in_progress")
 
-    def _cancel_shipment_advice(self, shipment_advice, dock=None):
-        self._confirm_shipment_advice(shipment_advice)
+    @classmethod
+    def cancel_shipment_advice(cls, shipment_advice, dock=None):
+        cls.confirm_shipment_advice(shipment_advice)
+        if shipment_advice.state != "confirmed":
+            return
         shipment_advice.action_cancel()
-        self.assertEqual(shipment_advice.state, "cancel")
 
-    def _plan_records_in_shipment(self, shipment_advice, records, user=None):
-        wiz_model = self.env["wizard.plan.shipment"].with_context(
+    @classmethod
+    def plan_records_in_shipment(cls, shipment_advice, records, user=None):
+        wiz_model = cls.env["wizard.plan.shipment"].with_context(
             active_model=records._name,
             active_ids=records.ids,
         )
@@ -157,8 +161,9 @@ class Common(TransactionCase):
         wiz.action_plan()
         return wiz
 
-    def _unplan_records_from_shipment(self, records, user=None):
-        wiz_model = self.env["wizard.unplan.shipment"].with_context(
+    @classmethod
+    def unplan_records_from_shipment(cls, records, user=None):
+        wiz_model = cls.env["wizard.unplan.shipment"].with_context(
             active_model=records._name,
             active_ids=records.ids,
         )
@@ -168,9 +173,10 @@ class Common(TransactionCase):
         wiz.action_unplan()
         return wiz
 
-    def _load_records_in_shipment(self, shipment_advice, records, user=None):
+    @classmethod
+    def load_records_in_shipment(cls, shipment_advice, records, user=None):
         """Load pickings, move lines or package levels in the givent shipment."""
-        wiz_model = self.env["wizard.load.shipment"].with_context(
+        wiz_model = cls.env["wizard.load.shipment"].with_context(
             active_model=records._name,
             active_ids=records.ids,
         )
@@ -180,9 +186,10 @@ class Common(TransactionCase):
         wiz.action_load()
         return wiz
 
-    def _unload_records_from_shipment(self, shipment_advice, records):
+    @classmethod
+    def unload_records_from_shipment(cls, shipment_advice, records):
         """Unload pickings, move lines or package levels from the givent shipment."""
-        wiz_model = self.env["wizard.unload.shipment"].with_context(
+        wiz_model = cls.env["wizard.unload.shipment"].with_context(
             active_model=records._name,
             active_ids=records.ids,
         )

--- a/shipment_advice/tests/common.py
+++ b/shipment_advice/tests/common.py
@@ -157,6 +157,17 @@ class Common(TransactionCase):
         wiz.action_plan()
         return wiz
 
+    def _unplan_records_from_shipment(self, records, user=None):
+        wiz_model = self.env["wizard.unplan.shipment"].with_context(
+            active_model=records._name,
+            active_ids=records.ids,
+        )
+        wiz = wiz_model.create({})
+        if user:
+            wiz = wiz.with_user(user)
+        wiz.action_unplan()
+        return wiz
+
     def _load_records_in_shipment(self, shipment_advice, records, user=None):
         """Load pickings, move lines or package levels in the givent shipment."""
         wiz_model = self.env["wizard.load.shipment"].with_context(

--- a/shipment_advice/tests/common.py
+++ b/shipment_advice/tests/common.py
@@ -3,7 +3,7 @@
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import fields
-from odoo.tests.common import TransactionCase, new_test_user
+from odoo.tests.common import Form, TransactionCase, new_test_user
 
 
 class Common(TransactionCase):
@@ -196,3 +196,19 @@ class Common(TransactionCase):
         wiz = wiz_model.create({})
         wiz.action_unload()
         return wiz
+
+    @classmethod
+    def validate_picking(cls, picking, qty_done=None):
+        picking.ensure_one()
+        for ml in picking.move_line_ids:
+            ml.qty_done = qty_done or ml.reserved_uom_qty
+        action_data = picking.button_validate()
+        if action_data is True:
+            return cls.env["stock.picking"]
+        backorder_wizard = Form(
+            cls.env["stock.backorder.confirmation"].with_context(
+                **action_data["context"]
+            )
+        ).save()
+        backorder_wizard.process()
+        return cls.env["stock.picking"].search([("backorder_id", "=", picking.id)])

--- a/shipment_advice/tests/test_shipment_advice.py
+++ b/shipment_advice/tests/test_shipment_advice.py
@@ -24,7 +24,7 @@ class TestShipmentAdvice(Common):
             self.shipment_advice_out.action_confirm()
 
     def test_shipment_advice_in_progress(self):
-        self._confirm_shipment_advice(self.shipment_advice_out)
+        self.confirm_shipment_advice(self.shipment_advice_out)
         with self.assertRaises(UserError):
             self.shipment_advice_out.action_in_progress()
         self.shipment_advice_out.dock_id = self.dock
@@ -41,8 +41,8 @@ class TestShipmentAdvice(Common):
         with self.assertRaises(UserError):
             self.shipment_advice_in.action_done()
         self._check_sequence(self.shipment_advice_in)
-        self._plan_records_in_shipment(self.shipment_advice_in, picking)
-        self._in_progress_shipment_advice(self.shipment_advice_in)
+        self.plan_records_in_shipment(self.shipment_advice_in, picking)
+        self.progress_shipment_advice(self.shipment_advice_in)
         for ml in picking.move_line_ids:
             ml.qty_done = ml.reserved_uom_qty
         picking._action_done()
@@ -62,8 +62,8 @@ class TestShipmentAdvice(Common):
         """
         picking = self.move_product_in1.picking_id
         # Plan a move
-        self._plan_records_in_shipment(self.shipment_advice_in, self.move_product_in1)
-        self._in_progress_shipment_advice(self.shipment_advice_in)
+        self.plan_records_in_shipment(self.shipment_advice_in, self.move_product_in1)
+        self.progress_shipment_advice(self.shipment_advice_in)
         # Receive it (making its related transfer partially received)
         for ml in self.move_product_in1.move_line_ids:
             ml.qty_done = ml.reserved_uom_qty
@@ -82,8 +82,8 @@ class TestShipmentAdvice(Common):
         validate all fully loaded transfers.
         """
         picking = self.move_product_out1.picking_id
-        self._in_progress_shipment_advice(self.shipment_advice_out)
-        self._load_records_in_shipment(self.shipment_advice_out, picking)
+        self.progress_shipment_advice(self.shipment_advice_out)
+        self.load_records_in_shipment(self.shipment_advice_out, picking)
         self.shipment_advice_out.action_done()
         self.assertEqual(self.shipment_advice_out.state, "done")
         self.assertTrue(
@@ -103,8 +103,8 @@ class TestShipmentAdvice(Common):
         company.shipment_advice_outgoing_backorder_policy = "leave_open"
         # Load a transfer partially (here a package)
         package_level = self.move_product_out2.move_line_ids.package_level_id
-        self._in_progress_shipment_advice(self.shipment_advice_out)
-        self._load_records_in_shipment(self.shipment_advice_out, package_level)
+        self.progress_shipment_advice(self.shipment_advice_out)
+        self.load_records_in_shipment(self.shipment_advice_out, package_level)
         # Validate the shipment => the transfer is still open
         self.shipment_advice_out.action_done()
         picking = package_level.picking_id
@@ -127,8 +127,8 @@ class TestShipmentAdvice(Common):
         company.shipment_advice_outgoing_backorder_policy = "create_backorder"
         # Load a transfer partially (here a package)
         package_level = self.move_product_out2.move_line_ids.package_level_id
-        self._in_progress_shipment_advice(self.shipment_advice_out)
-        self._load_records_in_shipment(self.shipment_advice_out, package_level)
+        self.progress_shipment_advice(self.shipment_advice_out)
+        self.load_records_in_shipment(self.shipment_advice_out, package_level)
         self.assertEqual(package_level.picking_id, self.move_product_out1.picking_id)
         # Validate the shipment => the transfer is validated, creating a backorder
         self.shipment_advice_out.action_done()
@@ -148,7 +148,7 @@ class TestShipmentAdvice(Common):
         self.assertEqual(picking2.state, "assigned")
 
     def test_shipment_advice_cancel(self):
-        self._in_progress_shipment_advice(self.shipment_advice_out)
+        self.progress_shipment_advice(self.shipment_advice_out)
         self.shipment_advice_out.action_cancel()
         self.assertEqual(self.shipment_advice_out.state, "cancel")
 
@@ -160,7 +160,7 @@ class TestShipmentAdvice(Common):
     def test_shipment_advice_draft(self):
         with self.assertRaises(UserError):
             self.shipment_advice_out.action_draft()
-        self._cancel_shipment_advice(self.shipment_advice_out)
+        self.cancel_shipment_advice(self.shipment_advice_out)
         self.shipment_advice_out.action_draft()
         self.assertEqual(self.shipment_advice_out.state, "draft")
 

--- a/shipment_advice/tests/test_shipment_advice.py
+++ b/shipment_advice/tests/test_shipment_advice.py
@@ -163,3 +163,7 @@ class TestShipmentAdvice(Common):
         self._cancel_shipment_advice(self.shipment_advice_out)
         self.shipment_advice_out.action_draft()
         self.assertEqual(self.shipment_advice_out.state, "draft")
+
+    def test_shipment_name(self):
+        self.assertTrue("OUT" in self.shipment_advice_out.name)
+        self.assertTrue("IN" in self.shipment_advice_in.name)

--- a/shipment_advice/tests/test_shipment_advice_async.py
+++ b/shipment_advice/tests/test_shipment_advice_async.py
@@ -50,8 +50,8 @@ class TestShipmentAdvice(Common):
         transfers. Here the planned transfers have been fully received.
         """
         picking = self.move_product_in1.picking_id
-        self._plan_records_in_shipment(self.shipment_advice_in, picking)
-        self._in_progress_shipment_advice(self.shipment_advice_in)
+        self.plan_records_in_shipment(self.shipment_advice_in, picking)
+        self.progress_shipment_advice(self.shipment_advice_in)
         for ml in picking.move_line_ids:
             ml.qty_done = ml.reserved_uom_qty
         picking._action_done()
@@ -79,8 +79,8 @@ class TestShipmentAdvice(Common):
         """
         picking = self.move_product_in1.picking_id
         # Plan a move
-        self._plan_records_in_shipment(self.shipment_advice_in, self.move_product_in1)
-        self._in_progress_shipment_advice(self.shipment_advice_in)
+        self.plan_records_in_shipment(self.shipment_advice_in, self.move_product_in1)
+        self.progress_shipment_advice(self.shipment_advice_in)
         # Receive it (making its related transfer partially received)
         for ml in self.move_product_in1.move_line_ids:
             ml.qty_done = ml.reserved_uom_qty
@@ -107,8 +107,8 @@ class TestShipmentAdvice(Common):
         validate all fully loaded transfers.
         """
         pickings = self.move1.picking_id | self.move2.picking_id | self.move3.picking_id
-        self._in_progress_shipment_advice(self.shipment_advice_out)
-        self._load_records_in_shipment(self.shipment_advice_out, pickings)
+        self.progress_shipment_advice(self.shipment_advice_out)
+        self.load_records_in_shipment(self.shipment_advice_out, pickings)
         with trap_jobs() as trap:
             self.shipment_advice_out.action_done()
             trap.assert_jobs_count(5)  # 3 pickings + 1 for unplan + 1 for postprocess
@@ -135,8 +135,8 @@ class TestShipmentAdvice(Common):
         company.shipment_advice_outgoing_backorder_policy = "leave_open"
         # Load a transfer partially (here a package)
         package_level = self.move_product_out2.move_line_ids.package_level_id
-        self._in_progress_shipment_advice(self.shipment_advice_out)
-        self._load_records_in_shipment(self.shipment_advice_out, package_level)
+        self.progress_shipment_advice(self.shipment_advice_out)
+        self.load_records_in_shipment(self.shipment_advice_out, package_level)
         # Validate the shipment => the transfer is still open
         with trap_jobs() as trap:
             self.shipment_advice_out.action_done()
@@ -167,8 +167,8 @@ class TestShipmentAdvice(Common):
         company.shipment_advice_outgoing_backorder_policy = "create_backorder"
         # Load a transfer partially (here a package)
         package_level = self.move_product_out2.move_line_ids.package_level_id
-        self._in_progress_shipment_advice(self.shipment_advice_out)
-        self._load_records_in_shipment(self.shipment_advice_out, package_level)
+        self.progress_shipment_advice(self.shipment_advice_out)
+        self.load_records_in_shipment(self.shipment_advice_out, package_level)
         self.assertEqual(package_level.picking_id, self.move_product_out1.picking_id)
         # Validate the shipment => the transfer is validated, creating a backorder
         with trap_jobs() as trap:
@@ -202,8 +202,8 @@ class TestShipmentAdvice(Common):
             - the shipment advice moves to the "error" state
         """
         pickings = self.move1.picking_id | self.move2.picking_id | self.move3.picking_id
-        self._in_progress_shipment_advice(self.shipment_advice_out)
-        self._load_records_in_shipment(self.shipment_advice_out, pickings)
+        self.progress_shipment_advice(self.shipment_advice_out)
+        self.load_records_in_shipment(self.shipment_advice_out, pickings)
         # provoke validation error by setting internal package as destination
         pickings[0].move_line_ids.result_package_id = self.package
         with trap_jobs() as trap:
@@ -279,10 +279,10 @@ class TestShipmentAdvice(Common):
         # Load a transfer partially (here a package)
         package_level = self.move_product_out2.move_line_ids.package_level_id
         picking = package_level.picking_id
-        self._in_progress_shipment_advice(self.shipment_advice_out)
-        self._plan_records_in_shipment(self.shipment_advice_out, picking)
+        self.progress_shipment_advice(self.shipment_advice_out)
+        self.plan_records_in_shipment(self.shipment_advice_out, picking)
         self.assertEqual(len(self.shipment_advice_out.planned_move_ids), 3)
-        self._load_records_in_shipment(self.shipment_advice_out, package_level)
+        self.load_records_in_shipment(self.shipment_advice_out, package_level)
         self.assertEqual(len(package_level.move_line_ids.move_id), 2)
         # Validate the shipment => the transfer is validated, creating a backorder
         with trap_jobs() as trap:

--- a/shipment_advice/tests/test_shipment_advice_auto_close.py
+++ b/shipment_advice/tests/test_shipment_advice_auto_close.py
@@ -1,0 +1,46 @@
+# Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from .common import Common
+
+
+class TestShipmentAdviceAutoClose(Common):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.shipment_advice_in.company_id.shipment_advice_auto_close_incoming = True
+        cls.picking1 = cls.move_product_in1.picking_id
+        group = cls.env["procurement.group"].create({})
+        cls.move_product_in21 = cls._create_move(
+            cls.picking_type_in, cls.product_in, 5, group
+        )
+        cls.picking2 = cls.move_product_in21.picking_id
+        cls.pickings = cls.picking1 | cls.picking2
+        cls.plan_records_in_shipment(cls.shipment_advice_in, cls.pickings)
+        cls.progress_shipment_advice(cls.shipment_advice_in)
+
+    def test_auto_close_incoming_on_done(self):
+        self.validate_picking(self.picking1)
+        self.assertEqual(self.shipment_advice_in.state, "in_progress")
+        self.validate_picking(self.picking2)
+        self.assertEqual(self.shipment_advice_in.state, "done")
+
+    def test_auto_close_incoming_on_cancel(self):
+        self.validate_picking(self.picking1)
+        self.assertEqual(self.shipment_advice_in.state, "in_progress")
+        self.picking2.action_cancel()
+        self.assertEqual(self.shipment_advice_in.state, "done")
+
+    def test_no_auto_close_on_outgoing(self):
+        picking = self.move_product_out1.picking_id
+        self.plan_records_in_shipment(self.shipment_advice_out, picking)
+        self.progress_shipment_advice(self.shipment_advice_out)
+        self.validate_picking(picking)
+        self.assertEqual(picking.state, "done")
+        self.assertEqual(self.shipment_advice_out.state, "in_progress")
+
+    def test_no_auto_close_context(self):
+        pickings = self.pickings.with_context(shipment_advice_ignore_auto_close=True)
+        for picking in pickings:
+            self.validate_picking(picking)
+        self.assertEqual(self.shipment_advice_in.state, "in_progress")

--- a/shipment_advice/tests/test_shipment_advice_load.py
+++ b/shipment_advice/tests/test_shipment_advice_load.py
@@ -8,7 +8,7 @@ from .common import Common
 
 class TestShipmentAdviceLoad(Common):
     def test_shipment_advice_load_picking_not_planned(self):
-        self._in_progress_shipment_advice(self.shipment_advice_out)
+        self.progress_shipment_advice(self.shipment_advice_out)
         picking = self.move_product_out1.picking_id
         wiz_model = self.env["wizard.load.shipment"].with_context(
             active_model=picking._name,
@@ -42,9 +42,9 @@ class TestShipmentAdviceLoad(Common):
 
     def test_shipment_advice_load_picking_already_planned(self):
         picking = self.move_product_out1.picking_id
-        self._plan_records_in_shipment(self.shipment_advice_out, picking)
-        self._in_progress_shipment_advice(self.shipment_advice_out)
-        wiz = self._load_records_in_shipment(self.shipment_advice_out, picking)
+        self.plan_records_in_shipment(self.shipment_advice_out, picking)
+        self.progress_shipment_advice(self.shipment_advice_out)
+        wiz = self.load_records_in_shipment(self.shipment_advice_out, picking)
         self.assertEqual(wiz.picking_ids, picking)
         self.assertFalse(wiz.move_line_ids)
         # Check planned entries
@@ -73,7 +73,7 @@ class TestShipmentAdviceLoad(Common):
         self.assertEqual(wiz.shipment_advice_id.loaded_package_ids, self.package)
 
     def test_shipment_advice_load_move_line_not_planned(self):
-        self._in_progress_shipment_advice(self.shipment_advice_out)
+        self.progress_shipment_advice(self.shipment_advice_out)
         move = self.move_product_out1
         wiz_model = self.env["wizard.load.shipment"].with_context(
             active_model=move.move_line_ids._name,
@@ -101,9 +101,9 @@ class TestShipmentAdviceLoad(Common):
 
     def test_shipment_advice_load_move_line_already_planned(self):
         move = self.move_product_out1
-        self._plan_records_in_shipment(self.shipment_advice_out, move)
-        self._in_progress_shipment_advice(self.shipment_advice_out)
-        wiz = self._load_records_in_shipment(
+        self.plan_records_in_shipment(self.shipment_advice_out, move)
+        self.progress_shipment_advice(self.shipment_advice_out)
+        wiz = self.load_records_in_shipment(
             self.shipment_advice_out, move.move_line_ids
         )
         self.assertEqual(wiz.move_line_ids, move.move_line_ids)
@@ -127,8 +127,8 @@ class TestShipmentAdviceLoad(Common):
     def test_shipment_advice_load_moves_different_pack(self):
         move = self.move_product_out1
         move_package_ids = self.move_product_out2 + self.move_product_out3
-        self._plan_records_in_shipment(self.shipment_advice_out, move)
-        self._in_progress_shipment_advice(self.shipment_advice_out)
+        self.plan_records_in_shipment(self.shipment_advice_out, move)
+        self.progress_shipment_advice(self.shipment_advice_out)
         wiz_model = self.env["wizard.load.shipment"].with_context(
             active_model=move.move_line_ids._name,
             active_ids=move.move_line_ids.ids + move_package_ids.move_line_ids.ids,
@@ -140,12 +140,12 @@ class TestShipmentAdviceLoad(Common):
     def test_shipment_advice_already_planned_load_move_line_not_planned(self):
         # Plan the first move
         move1 = self.move_product_out1
-        self._plan_records_in_shipment(self.shipment_advice_out, move1)
+        self.plan_records_in_shipment(self.shipment_advice_out, move1)
         # But load something else => error
         package_level = self.move_product_out2.move_line_ids.package_level_id
-        self._in_progress_shipment_advice(self.shipment_advice_out)
+        self.progress_shipment_advice(self.shipment_advice_out)
         with self.assertRaisesRegex(UserError, "planned already"):
-            self._load_records_in_shipment(
+            self.load_records_in_shipment(
                 self.shipment_advice_out,
                 package_level,
             )

--- a/shipment_advice/tests/test_shipment_advice_picking_values.py
+++ b/shipment_advice/tests/test_shipment_advice_picking_values.py
@@ -8,7 +8,7 @@ class TestShipmentPickingValues(Common):
     def test_picking_loaded_waiting_quantity_no(self):
         move = self.move_product_out1
         picking = move.picking_id
-        self._load_records_in_shipment(self.shipment_advice_out, picking)
+        self.load_records_in_shipment(self.shipment_advice_out, picking)
         self.assertEqual(picking.loaded_waiting_quantity, 0)
 
     def test_picking_loaded_waiting_quantity_yes(self):
@@ -16,5 +16,5 @@ class TestShipmentPickingValues(Common):
         picking = move.picking_id
         quantity = move.product_qty
         move.move_line_ids.reserved_uom_qty = quantity - 3
-        self._load_records_in_shipment(self.shipment_advice_out, picking)
+        self.load_records_in_shipment(self.shipment_advice_out, picking)
         self.assertEqual(picking.loaded_waiting_quantity, 3)

--- a/shipment_advice/tests/test_shipment_advice_picking_values.py
+++ b/shipment_advice/tests/test_shipment_advice_picking_values.py
@@ -1,0 +1,20 @@
+# Copyright 2024 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
+
+from .common import Common
+
+
+class TestShipmentPickingValues(Common):
+    def test_picking_loaded_waiting_quantity_no(self):
+        move = self.move_product_out1
+        picking = move.picking_id
+        self._load_records_in_shipment(self.shipment_advice_out, picking)
+        self.assertEqual(picking.loaded_waiting_quantity, 0)
+
+    def test_picking_loaded_waiting_quantity_yes(self):
+        move = self.move_product_out1
+        picking = move.picking_id
+        quantity = move.product_qty
+        move.move_line_ids.reserved_uom_qty = quantity - 3
+        self._load_records_in_shipment(self.shipment_advice_out, picking)
+        self.assertEqual(picking.loaded_waiting_quantity, 3)

--- a/shipment_advice/tests/test_shipment_advice_plan.py
+++ b/shipment_advice/tests/test_shipment_advice_plan.py
@@ -7,7 +7,7 @@ from .common import Common
 class TestShipmentAdvicePlan(Common):
     def test_shipment_advice_plan_picking(self):
         picking = self.move_product_out1.picking_id
-        wiz = self._plan_records_in_shipment(self.shipment_advice_out, picking)
+        wiz = self.plan_records_in_shipment(self.shipment_advice_out, picking)
         self.assertEqual(wiz.picking_ids, picking)
         self.assertFalse(wiz.move_ids)
         self.assertEqual(wiz.shipment_advice_id, self.shipment_advice_out)
@@ -18,7 +18,7 @@ class TestShipmentAdvicePlan(Common):
 
     def test_shipment_advice_plan_move(self):
         picking = self.move_product_out1.picking_id
-        wiz = self._plan_records_in_shipment(
+        wiz = self.plan_records_in_shipment(
             self.shipment_advice_out, self.move_product_out1
         )
         self.assertEqual(wiz.move_ids, self.move_product_out1)

--- a/shipment_advice/tests/test_shipment_advice_stock_user.py
+++ b/shipment_advice/tests/test_shipment_advice_stock_user.py
@@ -80,13 +80,13 @@ class TestShipmentAdviceStockUser(Common):
 
     def test_wizard_plan_and_load_shipment(self):
         move = self.move_product_out1
-        self._plan_records_in_shipment(
+        self.plan_records_in_shipment(
             self.shipment_advice_out,
             move,
             user=self.stock_user,
         )
-        self._in_progress_shipment_advice(self.shipment_advice_out)
-        wiz = self._load_records_in_shipment(
+        self.progress_shipment_advice(self.shipment_advice_out)
+        wiz = self.load_records_in_shipment(
             self.shipment_advice_out,
             move.move_line_ids,
             user=self.stock_user,

--- a/shipment_advice/tests/test_shipment_advice_unload.py
+++ b/shipment_advice/tests/test_shipment_advice_unload.py
@@ -6,10 +6,10 @@ from .common import Common
 
 class TestShipmentAdviceUnload(Common):
     def test_shipment_advice_unload_picking(self):
-        self._in_progress_shipment_advice(self.shipment_advice_out)
+        self.progress_shipment_advice(self.shipment_advice_out)
         # Load picking
         picking = self.move_product_out1.picking_id
-        self._load_records_in_shipment(self.shipment_advice_out, picking)
+        self.load_records_in_shipment(self.shipment_advice_out, picking)
         self.assertEqual(self.shipment_advice_out.loaded_picking_ids, picking)
         self.assertEqual(
             self.shipment_advice_out.loaded_move_line_ids,
@@ -18,29 +18,29 @@ class TestShipmentAdviceUnload(Common):
             | self.move_product_out3.move_line_ids,
         )
         # Unload it
-        self._unload_records_from_shipment(self.shipment_advice_out, picking)
+        self.unload_records_from_shipment(self.shipment_advice_out, picking)
         self.assertFalse(self.shipment_advice_out.loaded_picking_ids)
         self.assertFalse(self.shipment_advice_out.loaded_move_line_ids)
 
     def test_shipment_advice_unload_move_line(self):
-        self._in_progress_shipment_advice(self.shipment_advice_out)
+        self.progress_shipment_advice(self.shipment_advice_out)
         # Load move line
         move_line = self.move_product_out1.move_line_ids
-        self._load_records_in_shipment(self.shipment_advice_out, move_line)
+        self.load_records_in_shipment(self.shipment_advice_out, move_line)
         self.assertEqual(move_line.qty_done, 20)
         self.assertEqual(
             self.shipment_advice_out.loaded_move_line_without_package_ids, move_line
         )
         # Unload it
-        self._unload_records_from_shipment(self.shipment_advice_out, move_line)
+        self.unload_records_from_shipment(self.shipment_advice_out, move_line)
         self.assertFalse(move_line.qty_done)
         self.assertFalse(self.shipment_advice_out.loaded_move_line_without_package_ids)
 
     def test_shipment_advice_unload_package_level(self):
-        self._in_progress_shipment_advice(self.shipment_advice_out)
+        self.progress_shipment_advice(self.shipment_advice_out)
         # Load package level
         package_level = self.move_product_out2.move_line_ids.package_level_id
-        self._load_records_in_shipment(self.shipment_advice_out, package_level)
+        self.load_records_in_shipment(self.shipment_advice_out, package_level)
         self.assertTrue(package_level.is_done)
         self.assertEqual(self.move_product_out2.move_line_ids.qty_done, 10)
         self.assertEqual(self.move_product_out3.move_line_ids.qty_done, 10)

--- a/shipment_advice/views/res_config_settings.xml
+++ b/shipment_advice/views/res_config_settings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Copyright 2021 Camptocamp SA
+     Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
      License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl). -->
 <odoo>
     <record id="res_config_settings_view_form" model="ir.ui.view">
@@ -41,6 +42,23 @@
                             To prevent timeouts for large shipments, enable this option to execute
                             shipment advice validation through a queued job. Each picking will be
                             validated in a separate jobs.
+                        </div>
+                    </div>
+                </div>
+                <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    id="shipment_advice_auto_close_incoming"
+                    title="shipment_advice_auto_close_incoming"
+                >
+                    <div class="o_setting_left_pane">
+                        <field name="shipment_advice_auto_close_incoming" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="shipment_advice_auto_close_incoming" />
+                        <div class="text-muted">
+                            This flag indicates if an incoming shipment advice
+                            will be automatically set to done
+                            if all related moves are done or canceled
                         </div>
                     </div>
                 </div>

--- a/shipment_advice/views/shipment_advice.xml
+++ b/shipment_advice/views/shipment_advice.xml
@@ -186,7 +186,10 @@
                                 groups="!base.group_multi_company"
                                 invisible="1"
                             />
-                            <field name="shipment_type" />
+                            <field
+                                name="shipment_type"
+                                attrs="{'readonly': [('name', '!=', '/')]}"
+                            />
                         </group>
                         <group name="info2">
                             <field

--- a/shipment_advice/views/stock_picking.xml
+++ b/shipment_advice/views/stock_picking.xml
@@ -120,6 +120,7 @@
                 <field name="loaded_move_lines_progress" />
                 <field name="loaded_weight_progress" />
                 <field name="state" />
+                <field name="loaded_waiting_quantity" />
             </tree>
         </field>
     </record>


### PR DESCRIPTION
Port of the following PRs from 14.0 to 16.0:
- #117
- #100 
- commit 55e1e9f0 from #120
- commit 016fc52f + 509b38955958800523404acbcf0482edb16902d0 from #132 that relates to `shipment_advice` only (other changes are part of modules not yet ported)