### PR TITLE
[16.0][IMP] Usability improvements: search loaded products + shipment advice on stock operation tree

### DIFF
--- a/shipment_advice/views/shipment_advice.xml
+++ b/shipment_advice/views/shipment_advice.xml
@@ -299,6 +299,7 @@
             <search string="Shipment Advices">
                 <field name="name" />
                 <field name="ref" />
+                <field name="loaded_move_line_ids" />
                 <filter
                     name="incoming"
                     string="Incoming"

--- a/shipment_advice/views/stock_move_line.xml
+++ b/shipment_advice/views/stock_move_line.xml
@@ -74,4 +74,15 @@
             </tree>
         </field>
     </record>
+
+    <record id="view_move_line_tree_detailed" model="ir.ui.view">
+        <field name="name">stock.move.line.tree.inherit</field>
+        <field name="model">stock.move.line</field>
+        <field name="inherit_id" ref="stock.view_move_line_tree_detailed" />
+        <field name="arch" type="xml">
+            <field name="location_dest_id" position="after">
+                <field name="shipment_advice_id" widget="many2one" optional="hide" />
+            </field>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
1.Show shipment advice on stock operations (if you want to search product and see quantity on which SA is planned/loaded)

![image](https://github.com/user-attachments/assets/cf5fc0d4-e65c-4e57-822b-311003b23c86)
![image](https://github.com/user-attachments/assets/451098fb-e120-44e9-8354-134bcba50687)


2. Also allow searching through loaded products in shipment advices.
![image](https://github.com/user-attachments/assets/aeb78173-d94d-45dd-9317-e25c373ecc69)
![image](https://github.com/user-attachments/assets/83407855-d7a0-4927-8636-e6b91f584ca8)


very functional I think