### PR TITLE
[16.0][FIX] shipment_advice: validate picking

### DIFF
--- a/shipment_advice/models/shipment_advice.py
+++ b/shipment_advice/models/shipment_advice.py
@@ -1,5 +1,6 @@
 # Copyright 2021 Camptocamp SA
 # Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
+# Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
 from odoo import _, api, fields, models
@@ -383,7 +384,7 @@ class ShipmentAdvice(models.Model):
                     wiz.pick_ids = picking
                     wiz.with_context(button_validate_picking_ids=picking.ids).process()
                 elif not picking._check_backorder():
-                    picking._action_done()
+                    picking.with_context(skip_backorder=True).button_validate()
         except UserError as error:
             self.write(
                 {

--- a/shipment_advice/readme/CONTRIBUTORS.rst
+++ b/shipment_advice/readme/CONTRIBUTORS.rst
@@ -4,6 +4,7 @@
 * `Trobz <https://trobz.com>`_:
   * Dung Tran <dungtd@trobz.com>
 * Michael Tietz (MT Software) <mtietz@mt-software.de>
+* Jacques-Etienne Baudoux <je@bcim.be>
 
 Design
 ~~~~~~


### PR DESCRIPTION
Always call button_validate()

The validation of the picking is performed by calling `button_validate()` and not directly `_action_done()`.

This allows also to benefit from the multi-company hook here https://github.com/OCA/multi-company/pull/753/files#diff-887fc40b5011f0f41e7c1db1ddfb21a411e31582e4dfe1bb94859d60a6715f94R15

cc @sebalix @sbejaoui 
