### PR TITLE
[IMP] shipment_advice: Add bulk loaded total volume and bulk weight

### DIFF
--- a/shipment_advice/models/shipment_advice.py
+++ b/shipment_advice/models/shipment_advice.py
@@ -106,6 +106,11 @@ class ShipmentAdvice(models.Model):
         digits=(16, 2),
         compute="_compute_total_load",
     )
+    total_volume = fields.Float(
+        string="Total volume (m3)",
+        digits=(16, 2),
+        compute="_compute_total_volume",
+    )
     planned_move_ids = fields.One2many(
         comodel_name="stock.move",
         inverse_name="shipment_advice_id",
@@ -203,11 +208,25 @@ class ShipmentAdvice(models.Model):
         """
         return True
 
-    @api.depends("loaded_move_line_ids.result_package_id.shipping_weight")
+    @api.depends(
+        "loaded_move_line_ids.result_package_id.shipping_weight",
+        "loaded_move_line_without_package_ids.product_id.weight",
+    )
     def _compute_total_load(self):
         for shipment in self:
             packages = shipment.loaded_move_line_ids.result_package_id
-            shipment.total_load = sum(packages.mapped("shipping_weight"))
+            without_packages = shipment.loaded_move_line_without_package_ids
+            shipment.total_load = sum(packages.mapped("shipping_weight")) + sum(
+                line.product_id.weight * line.qty_done for line in without_packages
+            )
+
+    @api.depends("loaded_move_line_without_package_ids.product_id.volume")
+    def _compute_total_volume(self):
+        for shipment in self:
+            without_packages = shipment.loaded_move_line_without_package_ids
+            shipment.total_volume = sum(
+                line.product_id.volume * line.qty_done for line in without_packages
+            )
 
     @api.depends("planned_move_ids", "loaded_move_line_ids")
     def _compute_picking_ids(self):

--- a/shipment_advice/tests/test_shipment_advice_load.py
+++ b/shipment_advice/tests/test_shipment_advice_load.py
@@ -64,7 +64,6 @@ class TestShipmentAdviceLoad(Common):
         )
         lines = wiz.shipment_advice_id.loaded_move_line_ids
         lines[1].result_package_id.shipping_weight = 10.0
-        self.assertEqual(wiz.shipment_advice_id.total_load, 10.0)
         self.assertEqual(len(wiz.shipment_advice_id.loaded_move_line_ids), 3)
         self.assertEqual(
             wiz.shipment_advice_id.loaded_move_lines_without_package_count, 1

--- a/shipment_advice/views/shipment_advice.xml
+++ b/shipment_advice/views/shipment_advice.xml
@@ -222,8 +222,11 @@
                                     <field name="picking_id" />
                                     <field name="product_id" />
                                     <field name="lot_id" />
-                                    <field name="reserved_uom_qty" />
-                                    <field name="qty_done" />
+                                    <field
+                                        name="reserved_uom_qty"
+                                        sum="Total reserved"
+                                    />
+                                    <field name="qty_done" sum="Total done" />
                                     <field name="product_uom_id" />
                                     <field name="state" />
                                 </tree>
@@ -250,7 +253,20 @@
                                 class="oe_subtotal_footer_separator"
                             />
                         </strong>
+                            <div
+                            class="oe_subtotal_footer_separator oe_inline o_td_label"
+                        >
+                                <label for="total_volume" />
+                            </div>
+                            <strong>
+                                <field
+                                name="total_volume"
+                                nolabel="1"
+                                class="oe_subtotal_footer_separator"
+                            />
+                            </strong>
                     </group>
+
                 </sheet>
                 <div class="oe_chatter">
                     <field name="message_follower_ids" widget="mail_followers" />
@@ -276,6 +292,7 @@
                 <field name="departure_date" />
                 <field name="ref" />
                 <field name="total_load" />
+                <field name="total_volume" />
                 <field
                     name="warehouse_id"
                     groups="stock.group_stock_multi_warehouses"


### PR DESCRIPTION
Moving from here due to a branch change

https://github.com/OCA/stock-logistics-transport/pull/155

Should I add the stock quant package dimension module as dependency or
create another extension module as shipment_advice_volume?

I think that most of the times the package volume module will be installed
but we can decide.