### PR TITLE
[18.0][FIX] tms: 'kanban-box' and duplicate label of 2 field

### DIFF
--- a/tms/models/res_config_settings.py
+++ b/tms/models/res_config_settings.py
@@ -33,7 +33,7 @@ class ResConfigSettings(models.TransientModel):
     )
 
     group_tms_uom = fields.Boolean(
-        string="Units of Measure", implied_group="uom.group_uom"
+        string="TMS Units of Measure", implied_group="uom.group_uom"
     )
 
     # Custom Fields

--- a/tms/views/res_config_settings.xml
+++ b/tms/views/res_config_settings.xml
@@ -14,14 +14,14 @@
                 >
                     <block title="Units" name="general_settings_container">
                         <setting id="tms_uom">
-                            <field name="group_tms_uom" string="Units of Measure" />
+                            <field name="group_tms_uom" string="TMS Units of Measure" />
                             <div class="content-group">
                                 <div class="mt8" invisible="not group_tms_uom">
                                     <button
                                         name="%(uom.product_uom_categ_form_action)d"
                                         icon="oi-arrow-right"
                                         type="action"
-                                        string="Units Of Measure"
+                                        string="TMS Units of Measure"
                                         class="btn-link"
                                     />
                                 </div>

--- a/tms/views/tms_crew.xml
+++ b/tms/views/tms_crew.xml
@@ -6,7 +6,7 @@
         <field name="arch" type="xml">
             <kanban class="o_kanban_mobile" sample="1">
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="card">
                         <div t-attf-class="oe_kanban_global_click card my-3">
                             <div class="card-body">
                                 <div class="d-flex align-items-center mb-2">

--- a/tms/views/tms_driver.xml
+++ b/tms/views/tms_driver.xml
@@ -105,7 +105,7 @@
                 <field name="mobile" />
                 <field name="avatar_128" />
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="card">
                         <div
                             t-attf-class="oe_kanban_global_click o_has_icon oe_kanban_content oe_kanban_card"
                         >

--- a/tms/views/tms_order.xml
+++ b/tms/views/tms_order.xml
@@ -237,7 +237,7 @@
                             </div>
                         </div>
                     </t>
-                    <t t-name="kanban-box">
+                    <t t-name="card">
                         <div
                             t-attf-class="oe_kanban_global_click o_has_icon oe_kanban_content oe_kanban_card"
                         >

--- a/tms/views/tms_team.xml
+++ b/tms/views/tms_team.xml
@@ -13,7 +13,7 @@
                 <field name="crew_ids" />
                 <field name="trips_todo_count" />
                 <templates>
-                    <t t-name="kanban-box">
+                    <t t-name="card">
                         <div
                             t-attf-class="oe_kanban_global_click o_has_icon oe_kanban_content oe_kanban_card"
                         >


### PR DESCRIPTION
 I identified two issues in the tms module that needed to be addressed. To resolve these issues, I created two separate commits:
- Commit 1: The `kanban-box` in the tms module was deprecated in Odoo. This commit replaces the `kanban-box` definition with the recommended `card` template to address the warning.
- Commit 2: The `group_tms_uom` field in the `tms` module had the same label as `group_uom` from the `product` module ("Units of Measure"), causing a conflict. This commit updates the label of group_tms_uom to ensure uniqueness.