### PR TITLE
[IMP] shipment_advice_planner_toursolver: allow manual tourSolver optimization

### DIFF
--- a/shipment_advice_planner_toursolver/models/shipment_advice.py
+++ b/shipment_advice_planner_toursolver/models/shipment_advice.py
@@ -81,10 +81,7 @@ class ShipmentAdvice(models.Model):
     @api.depends("state", "toursolver_task_id")
     def _compute_is_create_toursolver_task_allowed(self):
         for rec in self:
-            rec.is_create_toursolver_task_allowed = (
-                rec.state not in ("draft", "done", "cancel")
-                and not rec.toursolver_task_id
-            )
+            rec.is_create_toursolver_task_allowed = not rec.toursolver_task_id
 
     def create_toursolver_task(self):
         self.ensure_one()


### PR DESCRIPTION
Being able to request the TourSolver optimization from a shipment advice without any conditions, as long as the SA is no longer linked to any tourSolver task