### PR TITLE
[16.0][IMP] shipment_advice unload cancelled picking

### DIFF
--- a/shipment_advice/tests/test_shipment_advice_unload.py
+++ b/shipment_advice/tests/test_shipment_advice_unload.py
@@ -22,6 +22,18 @@ class TestShipmentAdviceUnload(Common):
         self.assertFalse(self.shipment_advice_out.loaded_picking_ids)
         self.assertFalse(self.shipment_advice_out.loaded_move_line_ids)
 
+    def test_shipment_advice_unload_canceled_picking(self):
+        self.progress_shipment_advice(self.shipment_advice_out)
+        # Load picking
+        picking = self.move_product_out1.picking_id
+        self.load_records_in_shipment(self.shipment_advice_out, picking)
+        self.assertEqual(self.shipment_advice_out.loaded_picking_ids, picking)
+        picking.action_cancel()
+        # Unload it
+        self.unload_records_from_shipment(self.shipment_advice_out, picking)
+        self.assertFalse(self.shipment_advice_out.loaded_picking_ids)
+        self.assertFalse(self.shipment_advice_out.loaded_move_line_ids)
+
     def test_shipment_advice_unload_move_line(self):
         self.progress_shipment_advice(self.shipment_advice_out)
         # Load move line

--- a/shipment_advice/views/stock_picking.xml
+++ b/shipment_advice/views/stock_picking.xml
@@ -28,7 +28,7 @@
                     type="object"
                     string="Unload from shipment"
                     class="btn-primary"
-                    attrs="{'invisible': ['|', '|', ('is_fully_loaded_in_shipment', '=', False), ('picking_type_code', '!=', 'outgoing'), ('state', 'in', ('cancel', 'done'))]}"
+                    attrs="{'invisible': ['|', '|', ('is_fully_loaded_in_shipment', '=', False), ('picking_type_code', '!=', 'outgoing'), ('state', 'in', ('done'))]}"
                 />
             </header>
             <xpath

--- a/shipment_advice/wizards/unload_shipment.py
+++ b/shipment_advice/wizards/unload_shipment.py
@@ -37,10 +37,10 @@ class WizardUnloadShipment(models.TransientModel):
     @api.model
     def _default_get_from_stock_picking(self, res, ids):
         pickings = self.env["stock.picking"].browse(ids)
-        # We keep only deliveries not canceled/done
+        # We keep only deliveries not done
         pickings_to_keep = pickings.filtered(
             lambda o: (
-                o.state not in ["cancel", "done"]
+                o.state != "done"
                 and o.move_line_ids.shipment_advice_id
                 and all(
                     state in ("in_progress", "error")


### PR DESCRIPTION
This improvement allow you to unload cancelled picking. 
It doesn't make sense to keep cancelled picking in shipment advice. Those cancelled picking will prevent shipment advice to be processed. Therefore we should be able to unload them.