### PR TITLE
[18.0][FIX] printing_auto_shipment_advice: change model on security rule

### DIFF
--- a/printing_auto_shipment_advice/security/ir_rule.xml
+++ b/printing_auto_shipment_advice/security/ir_rule.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
     <record id="ir_rule_user" model="ir.rule">
-        <field name="name">stock picking auto print</field>
+        <field name="name">shipment advice auto print</field>
         <field name="model_id" ref="printing_auto_base.model_printing_auto" />
-        <field name="domain_force">[("model", "=", "stock.picking.type")]</field>
+        <field name="domain_force">[("model", "=", "shipment.advice")]</field>
         <field name="groups" eval="[(4, ref('stock.group_stock_user'))]" />
         <field name="perm_create" eval="0" />
         <field name="perm_write" eval="0" />


### PR DESCRIPTION
This rule is already in `printing_auto_stock_picking`. It is duplicate.