### PR TITLE
[18.0][FIX] shipment_advice: Allow to process partial pickings in shipments

### DIFF
--- a/shipment_advice/models/shipment_advice.py
+++ b/shipment_advice/models/shipment_advice.py
@@ -395,13 +395,17 @@ class ShipmentAdvice(models.Model):
                     ]
                 ),
                 group(self.delayable(description=self.name)._unplan_undone_moves()),
-                group(self.delayable(description=self.name)._postprocess_action_done()),
+                group(
+                    self.delayable(description=self.name)._postprocess_action_done(
+                        backorder_policy
+                    )
+                ),
             ).delay()
             return
         for picking in pickings:
             self._validate_picking(picking, backorder_policy)
         self._unplan_undone_moves()
-        self._postprocess_action_done()
+        self._postprocess_action_done(backorder_policy)
 
     def _check_action_done_allowed(self):
         for shipment in self:
@@ -417,15 +421,13 @@ class ShipmentAdvice(models.Model):
         self._lock_records(picking)
         try:
             with self.env.cr.savepoint():
-                if (
-                    picking._check_backorder()
-                    and backorder_policy == "create_backorder"
-                ):
+                if not picking._check_backorder():
+                    picking.with_context(skip_backorder=True).button_validate()
+                elif backorder_policy == "create_backorder":
                     wiz = self.env["stock.backorder.confirmation"].create({})
                     wiz.pick_ids = picking
                     wiz.with_context(button_validate_picking_ids=picking.ids).process()
-                elif not picking._check_backorder():
-                    picking.with_context(skip_backorder=True).button_validate()
+
         except UserError as error:
             self.write(
                 {
@@ -444,18 +446,25 @@ class ShipmentAdvice(models.Model):
         ).filtered(lambda m: m.state not in ("cancel", "done") and not m.picked)
         moves_to_unplan.shipment_advice_id = False
 
-    def _postprocess_action_done(self):
+    def _postprocess_action_done(self, backorder_policy):
         self.ensure_one()
         if self.state != "in_process":
             return
-        if self._get_picking_to_process().filtered(
+        in_process_pickings = self._get_picking_to_process().filtered(
             lambda p: p.state not in ("done", "cancel")
-        ):
+        )
+        should_write_an_error = backorder_policy != "leave_open"
+        if in_process_pickings and should_write_an_error:
+            # This is normal to have pickings that aren't 100% processed if
+            # backorder_policy is leave open.
+            # This should never happen, as we have either created a backorder
+            # for the unprocessed moves, or we allow shipments with partial pickings.
             self.write(
                 {
                     "state": "error",
                     "error_message": self.env._(
-                        "One of the pickings to process failed to validate"
+                        "The following pickings failed to validate\n%s",
+                        ", ".join(in_process_pickings.mapped("name")),
                     ),
                 }
             )

--- a/shipment_advice/tests/test_shipment_advice.py
+++ b/shipment_advice/tests/test_shipment_advice.py
@@ -108,13 +108,16 @@ class TestShipmentAdvice(Common):
         # Validate the shipment => the transfer is still open
         self.shipment_advice_out.action_done()
         picking = package_level.picking_id
-        self.assertEqual(self.shipment_advice_out.state, "error")
+        # We allow to process shipment advices with partial pickings,
+        # this shouldn't raise an error.
+        self.assertEqual(self.shipment_advice_out.state, "done")
         # Check the transfer
         self.assertTrue(
-            all(
-                move_line.state == "assigned"
-                for move_line in package_level.move_line_ids
-            )
+            all(move_line.picked for move_line in package_level.move_line_ids)
+        )
+        # move 1 is still on the dock
+        self.assertFalse(
+            any(move_line.picked for move_line in self.move_product_out1.move_line_ids)
         )
         self.assertEqual(picking.state, "assigned")
 

--- a/shipment_advice/tests/test_shipment_advice_async.py
+++ b/shipment_advice/tests/test_shipment_advice_async.py
@@ -148,13 +148,16 @@ class TestShipmentAdvice(Common):
             self._asset_jobs_dependency(jobs)
             trap.perform_enqueued_jobs()
         picking = package_level.picking_id
-        self.assertEqual(self.shipment_advice_out.state, "error")
+        # We allow to process shipment advices with partial pickings,
+        # this shouldn't raise an error.
+        self.assertEqual(self.shipment_advice_out.state, "done")
         # Check the transfer
         self.assertTrue(
-            all(
-                move_line.state == "assigned"
-                for move_line in package_level.move_line_ids
-            )
+            all(move_line.picked for move_line in package_level.move_line_ids)
+        )
+        # move 1 is still on the dock
+        self.assertFalse(
+            any(move_line.picked for move_line in self.move_product_out1.move_line_ids)
         )
         self.assertEqual(picking.state, "assigned")
 


### PR DESCRIPTION
When backorder_policy is leave_open, we do not process the picking, but we should be able to process the shipment.