### PR TITLE
[Fix] shipment_advice : release the lock_records on picking if excepion raise

### DIFF
--- a/shipment_advice/models/shipment_advice.py
+++ b/shipment_advice/models/shipment_advice.py
@@ -374,9 +374,9 @@ class ShipmentAdvice(models.Model):
 
     def _validate_picking(self, picking, backorder_policy="create_backorder"):
         self.ensure_one()
-        self._lock_records(picking)
         try:
             with self.env.cr.savepoint():
+                self._lock_records(picking)
                 if (
                     picking._check_backorder()
                     and backorder_policy == "create_backorder"


### PR DESCRIPTION
We found that if a cron job executed this validate_picking method on a task and it failed for some reason, when the action was restarted, the lock was not released because the code attempted to perform an operation after locking (meaning that the lock would be released by the ~20m timeout defined in the database). 

case of error or rollback, the data will return on the self.env.cr.savepoint() that mean the lock will rest as it is because the update was not made and the retry of the job will retry to do all the method. 



performance issue.