### PR TITLE
[17.0] [FIX] tms_expense: Avoid creating employee when driver is external.

### DIFF
--- a/tms_expense/models/tms_driver.py
+++ b/tms_expense/models/tms_driver.py
@@ -10,7 +10,8 @@ class TmsDriver(models.Model):
     @api.model
     def create(self, vals):
         driver = super().create(vals)
-        self.create_driver_employee(driver)
+        if not vals["is_external"]:
+            self.create_driver_employee(driver)
         return driver
 
     @api.model


### PR DESCRIPTION
In the module tms_expense (v17.0), when trying to import drivers, the system tries to create an employee even when the driver is marked as "external".

Ref: #198 
