### PR TITLE
[18.0][FIX] shipment_advice: load package

### DIFF
--- a/shipment_advice/models/stock_package_level.py
+++ b/shipment_advice/models/stock_package_level.py
@@ -31,7 +31,6 @@ class StockPackageLevel(models.Model):
 
     def _load_in_shipment(self, shipment_advice):
         """Load the package levels into the given shipment advice."""
-        self.is_done = True
         self.move_line_ids._load_in_shipment(shipment_advice)
 
     def _unload_from_shipment(self):


### PR DESCRIPTION
Do not mark a package level as done but only its corresponding move lines.

This is due to a bug in odoo when the package has multiple move lines. The first move line will increase its quantity by the quantity of the move instead of the move line https://github.com/odoo/odoo/blob/7e8ad31f6d9049a09ba9f84ac804badc57a27664/addons/stock/models/stock_package_level.py#L64

Failing use case:
Move1 reserves full PACK1 and partial PACK2
Move2 reserves remaining PACK2

When PACK2 is marked as done, the reservation of Move1 changes to the total quantity of PACK1 + PACK2.

The package level code has been removed in odoo 19.0

cc @mmequignon @mt-software-de 