### PR TITLE
[16.0] [IMP] shipment_advice: add notes field to shipment advice

### DIFF
--- a/shipment_advice/models/shipment_advice.py
+++ b/shipment_advice/models/shipment_advice.py
@@ -201,6 +201,14 @@ class ShipmentAdvice(models.Model):
     )
 
     error_message = fields.Text(tracking=True)
+    notes = fields.Text(
+        states={
+            "draft": [("readonly", False)],
+            "confirmed": [("readonly", False)],
+            "in_progress": [("readonly", False)],
+        },
+        readonly=True,
+    )
 
     _sql_constraints = [
         (

--- a/shipment_advice/views/shipment_advice.xml
+++ b/shipment_advice/views/shipment_advice.xml
@@ -252,6 +252,9 @@
                         <page name="carriers" string="Related shipping methods">
                             <field name="carrier_ids" nolabel="1" />
                         </page>
+                        <page string="Notes" name="notes">
+                            <field name="notes" nolabel="1" />
+                        </page>
                     </notebook>
                     <group class="oe_right" name="total_load">
                         <div class="oe_subtotal_footer_separator oe_inline o_td_label">


### PR DESCRIPTION
Add notes field to shipment advice

<img width="1241" height="845" alt="image" src="https://github.com/user-attachments/assets/44aa522f-11d3-40f5-8397-e9a7b1716e75" />

@BinhexTeam