### PR TITLE
[18.0][FIX] Fix shipment advice function is_loaded_in_shipment

### DIFF
--- a/shipment_advice/models/stock_package_level.py
+++ b/shipment_advice/models/stock_package_level.py
@@ -42,4 +42,10 @@ class StockPackageLevel(models.Model):
 
     def _is_loaded_in_shipment(self):
         """Return `True` if the package levels are loaded in a shipment."""
-        return all([pl.is_done and pl.shipment_advice_id for pl in self])
+        return all(
+            [
+                all([line.picked for line in pl.move_line_ids])
+                and pl.shipment_advice_id
+                for pl in self
+            ]
+        )

--- a/shipment_advice/models/stock_package_level.py
+++ b/shipment_advice/models/stock_package_level.py
@@ -44,7 +44,8 @@ class StockPackageLevel(models.Model):
         """Return `True` if the package levels are loaded in a shipment."""
         return all(
             [
-                all([line.picked for line in pl.move_line_ids])
+                pl.move_line_ids
+                and all([line.picked for line in pl.move_line_ids])
                 and pl.shipment_advice_id
                 for pl in self
             ]

--- a/shipment_advice/tests/test_shipment_advice.py
+++ b/shipment_advice/tests/test_shipment_advice.py
@@ -170,3 +170,12 @@ class TestShipmentAdvice(Common):
     def test_shipment_name(self):
         self.assertTrue("OUT" in self.shipment_advice_out.name)
         self.assertTrue("IN" in self.shipment_advice_in.name)
+
+    def test_shipment_advice_package_level_loaded(self):
+        """Check the package level is loaded in shipment computation."""
+        package_level = self.move_product_out2.move_line_ids.package_level_id
+        self.progress_shipment_advice(self.shipment_advice_out)
+        self.assertFalse(package_level._is_loaded_in_shipment())
+        self.load_records_in_shipment(self.shipment_advice_out, package_level)
+        self.assertEqual(package_level.picking_id, self.move_product_out1.picking_id)
+        self.assertTrue(package_level._is_loaded_in_shipment())


### PR DESCRIPTION
Finally fixing the broken function after the commit described below

Revert 

* https://github.com/OCA/stock-logistics-transport/pull/200

It breaks the module `shopfloor_delivery_shipment`

Because this function https://github.com/OCA/stock-logistics-transport/blob/a1b8ac8386058b6e1fcdb1fac394ad2ef6bda7e5/shipment_advice/models/stock_package_level.py#L43 relies on the `is_done` field. And it is not covered by tests :disappointed: 

Also there is a fix proposed on odoo for the root cause of the issue 

* https://github.com/odoo/odoo/pull/242487