### PR TITLE
[16.0] [IMP] shipment_advice: support manual ordering for planned pickings

### DIFF
--- a/shipment_advice/models/shipment_advice.py
+++ b/shipment_advice/models/shipment_advice.py
@@ -3,8 +3,9 @@
 # Copyright 2025 Jacques-Etienne Baudoux (BCIM) <je@bcim.be>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
 
-from odoo import _, api, fields, models
+from odoo import Command, _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.tools.safe_eval import safe_eval
 
 from odoo.addons.queue_job.delay import chain, group
 from odoo.addons.queue_job.job import identity_exact
@@ -125,6 +126,15 @@ class ShipmentAdvice(models.Model):
         compute="_compute_picking_ids",
         string="Planned transfers",
     )
+
+    planned_picking_order_ids = fields.One2many(
+        "shipment.advice.planned.picking.order",
+        "shipment_advice_id",
+        string="Planned Pickings Order",
+        compute="_compute_planned_picking_order_ids",
+        store=True,
+    )
+
     planned_pickings_count = fields.Integer(compute="_compute_count")
     loaded_move_line_ids = fields.One2many(
         comodel_name="stock.move.line",
@@ -308,6 +318,27 @@ class ShipmentAdvice(models.Model):
             shipment.to_validate_picking_ids = self.env["stock.picking"].browse(
                 to_validate_picking_ids
             )
+
+    @api.depends("planned_picking_ids")
+    def _compute_planned_picking_order_ids(self):
+        for shipment in self:
+            # unplanned pickings
+            shipment.planned_picking_order_ids.filtered(
+                lambda it, s=shipment: it.stock_picking_id not in s.planned_picking_ids
+            ).unlink()
+            planned_pickings = [
+                Command.create(
+                    {
+                        "stock_picking_id": planned_picking.id,
+                        "sequence": 0,
+                    }
+                )
+                for planned_picking in (
+                    shipment.planned_picking_ids
+                    - shipment.planned_picking_order_ids.stock_picking_id
+                )
+            ]
+            shipment.planned_picking_order_ids = planned_pickings
 
     @api.depends(
         "loaded_move_line_ids.package_level_id.package_id",
@@ -575,19 +606,44 @@ class ShipmentAdvice(models.Model):
             shipment.state = "draft"
 
     def button_open_planned_pickings(self):
+        self.ensure_one()
         action_xmlid = "stock.action_picking_tree_all"
         action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
         action["domain"] = [("id", "in", self.planned_picking_ids.ids)]
+
+        context = (
+            safe_eval(
+                action.get("context", "{}"),
+                dict(self.env.context),
+                mode="exec",
+                nocopy=True,
+            )
+            or {}
+        )
+        context.update({"active_shipment_advice_id": self.id})
+        action["context"] = context
+
+        tree_view = self.env.ref(
+            "shipment_advice.vpicktree_planned_shipment_advice_order"
+        )
+        tree_view_index = action["views"].index((False, "tree"))
+        action["views"][tree_view_index] = (tree_view.id, "tree")
         return action
 
     def button_open_planned_moves(self):
+        self.ensure_one()
         action_xmlid = "stock.stock_move_action"
         action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
         action["views"] = [
-            (self.env.ref("stock.view_picking_move_tree").id, "tree"),
+            (self.env.ref("shipment_advice.view_picking_move_tree").id, "tree"),
         ]
         action["domain"] = [("id", "in", self.planned_move_ids.ids)]
         action["context"] = {}  # Disable filters
+        active_shipment_advice_id = self.id
+        if active_shipment_advice_id:
+            action["context"].update(
+                {"active_shipment_advice_id": active_shipment_advice_id}
+            )
         return action
 
     def button_open_loaded_pickings(self):
@@ -664,3 +720,40 @@ class ShipmentAdvice(models.Model):
         action["views"][tree_view_index] = (view_tree.id, "tree")
         action["domain"] = [("id", "in", self.planned_picking_ids.ids)]
         return action
+
+
+class ShipmentAdvicePlannedPickingOrder(models.Model):
+    _name = "shipment.advice.planned.picking.order"
+    _description = "Shipment Advice Planned Picking Order"
+    _order = "shipment_advice_id, sequence"
+    _check_company_auto = True
+
+    shipment_advice_id = fields.Many2one(
+        comodel_name="shipment.advice",
+        string="Shipment Advice",
+        required=True,
+        ondelete="cascade",
+        index=True,
+    )
+    stock_picking_id = fields.Many2one(
+        comodel_name="stock.picking",
+        string="Planned Picking",
+        required=True,
+        ondelete="cascade",
+        check_company=True,
+        index=True,
+    )
+    sequence = fields.Integer(default=0)
+    company_id = fields.Many2one(
+        related="shipment_advice_id.company_id",
+        store=True,
+        readonly=True,
+    )
+
+    _sql_constraints = [
+        (
+            "shipment_advice_planned_picking_uniq",
+            "unique(shipment_advice_id, stock_picking_id)",
+            "A stock picking can only be planned once per shipment advice.",
+        ),
+    ]

--- a/shipment_advice/models/stock_move.py
+++ b/shipment_advice/models/stock_move.py
@@ -1,8 +1,7 @@
 # Copyright 2021 Camptocamp SA
 # Copyright 2024 Michael Tietz (MT Software) <mtietz@mt-software.de>
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl)
-
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockMove(models.Model):
@@ -15,6 +14,22 @@ class StockMove(models.Model):
         index=True,
         copy=False,
     )
+
+    picking_sequence_in_shipment_advice = fields.Integer(
+        compute="_compute_picking_sequence_in_shipment_advice"
+    )
+
+    @api.depends_context("active_shipment_advice_id")
+    def _compute_picking_sequence_in_shipment_advice(self):
+        shipment_advice_id = self.env.context.get("active_shipment_advice_id")
+
+        for move in self:
+            picking_sequence = False
+            if shipment_advice_id:
+                picking_sequence = move.picking_id.with_context(
+                    active_shipment_advice_id=shipment_advice_id
+                ).sequence_in_shipment_advice
+            move.picking_sequence_in_shipment_advice = picking_sequence
 
     def _plan_in_shipment(self, shipment_advice):
         """Plan the moves into the given shipment advice."""
@@ -34,4 +49,19 @@ class StockMove(models.Model):
     def _action_cancel(self):
         res = super()._action_cancel()
         self.shipment_advice_id.auto_close_incoming_shipment_advices()
+        return res
+
+    @api.model
+    def search(self, domain, offset=0, limit=None, order=None, count=False):
+        res = super().search(
+            domain, offset=offset, limit=limit, order=order, count=count
+        )
+        # if this is used to count, sorting does not make sense, also if limit is set
+        # at this point sorting for what?
+        if (
+            self.env.context.get("active_shipment_advice_id")
+            and not count
+            and not limit
+        ):
+            res = res.sorted("picking_sequence_in_shipment_advice")
         return res

--- a/shipment_advice/models/stock_picking.py
+++ b/shipment_advice/models/stock_picking.py
@@ -14,6 +14,17 @@ class StockPicking(models.Model):
         store=True,
         index=True,
     )
+
+    shipment_advice_planned_picking_order_ids = fields.One2many(
+        comodel_name="shipment.advice.planned.picking.order",
+        inverse_name="stock_picking_id",
+    )
+
+    sequence_in_shipment_advice = fields.Integer(
+        compute="_compute_sequence_in_shipment_advice",
+        inverse="_inverse_sequence_in_shipment_advice",
+    )
+
     is_fully_loaded_in_shipment = fields.Boolean(
         string="Is fully loaded in a shipment?",
         compute="_compute_loaded_in_shipment",
@@ -174,6 +185,29 @@ class StockPicking(models.Model):
                 picking.loaded_progress_f = picking.loaded_move_lines_progress_f
                 picking.loaded_progress = picking.loaded_move_lines_progress
 
+    @api.depends("shipment_advice_planned_picking_order_ids.sequence")
+    @api.depends_context("active_shipment_advice_id")
+    def _compute_sequence_in_shipment_advice(self):
+        for picking in self:
+            planned_order = picking.shipment_advice_planned_picking_order_ids.filtered(
+                lambda r: r.shipment_advice_id.id
+                == self.env.context.get("active_shipment_advice_id")
+            )
+            picking.sequence_in_shipment_advice = (
+                planned_order.sequence if planned_order else False
+            )
+
+    def _inverse_sequence_in_shipment_advice(self):
+        for picking in self:
+            if not (active_id := self.env.context.get("active_shipment_advice_id")):
+                return
+
+            planned_order = picking.shipment_advice_planned_picking_order_ids.filtered(
+                lambda r: r.shipment_advice_id.id == active_id
+            )
+            if planned_order:
+                planned_order.sequence = picking.sequence_in_shipment_advice
+
     def button_plan_in_shipment(self):
         action_xmlid = "shipment_advice.wizard_plan_shipment_picking_action"
         action = self.env["ir.actions.act_window"]._for_xml_id(action_xmlid)
@@ -205,3 +239,19 @@ class StockPicking(models.Model):
         """Unload the whole transfers content from their related shipment advice."""
         self.package_level_ids._unload_from_shipment()
         self.move_line_ids._unload_from_shipment()
+
+    @api.model
+    def search(self, domain, offset=0, limit=None, order=None, count=False):
+        res = super().search(
+            domain, offset=offset, limit=limit, order=order, count=count
+        )
+        # if this is used to count, sorting does not make sense, also if limit is set
+        # at this point sorting for what?
+
+        if (
+            self.env.context.get("active_shipment_advice_id")
+            and not count
+            and not limit
+        ):
+            res = res.sorted("sequence_in_shipment_advice")
+        return res

--- a/shipment_advice/report/report_shipment_advice.xml
+++ b/shipment_advice/report/report_shipment_advice.xml
@@ -80,7 +80,7 @@
                         </thead>
                         <tbody>
                             <tr
-                                t-foreach="o.loaded_package_level_ids.sorted(lambda r: r.picking_id.name)"
+                                t-foreach="o.loaded_package_level_ids.sorted(lambda r: r.with_context(active_shipment_advice_id=o.id).picking_id.sequence_in_shipment_advice)"
                                 t-as="package_level"
                             >
                                 <td>
@@ -131,7 +131,7 @@
                         </thead>
                         <tbody>
                             <tr
-                                t-foreach="o.loaded_move_line_without_package_ids"
+                                t-foreach="o.loaded_move_line_without_package_ids.sorted(lambda r: (r.move_id.with_context(active_shipment_advice_id=o.id).picking_sequence_in_shipment_advice, 'sequence'))"
                                 t-as="line"
                             >
                                 <td>

--- a/shipment_advice/security/ir.model.access.csv
+++ b/shipment_advice/security/ir.model.access.csv
@@ -4,3 +4,4 @@ access_wizard_plan_shipment_user,wizard.plan.shipment user,model_wizard_plan_shi
 access_wizard_unplan_shipment_user,wizard.unplan.shipment user,model_wizard_unplan_shipment,stock.group_stock_user,1,1,1,0
 access_wizard_load_shipment_user,wizard.load.shipment user,model_wizard_load_shipment,stock.group_stock_user,1,1,1,0
 access_wizard_unload_shipment_user,wizard.unload.shipment user,model_wizard_unload_shipment,stock.group_stock_user,1,1,1,0
+access_shipment_advice_planned_picking_order,shipment.advice.planned.picking.order user,model_shipment_advice_planned_picking_order,stock.group_stock_user,1,1,1,0

--- a/shipment_advice/tests/test_shipment_advice_plan.py
+++ b/shipment_advice/tests/test_shipment_advice_plan.py
@@ -5,8 +5,14 @@ from .common import Common
 
 
 class TestShipmentAdvicePlan(Common):
+    def _create_distinct_picking(self, picking_type, product, qty):
+        group2 = self.env["procurement.group"].create({})
+        return self._create_move(picking_type, product, qty, group2).picking_id
+
     def test_shipment_advice_plan_picking(self):
         picking = self.move_product_out1.picking_id
+
+        self.assertFalse(self.shipment_advice_out.planned_picking_order_ids)
         wiz = self.plan_records_in_shipment(self.shipment_advice_out, picking)
         self.assertEqual(wiz.picking_ids, picking)
         self.assertFalse(wiz.move_ids)
@@ -15,6 +21,68 @@ class TestShipmentAdvicePlan(Common):
         self.assertEqual(wiz.shipment_advice_id.planned_pickings_count, 1)
         self.assertEqual(wiz.shipment_advice_id.planned_move_ids, picking.move_ids)
         self.assertEqual(wiz.shipment_advice_id.planned_moves_count, 3)
+
+        # test generation of default order for pickings
+        picking2 = self._create_distinct_picking(
+            self.picking_type_out, self.product_out2, 5
+        )
+        self.plan_records_in_shipment(self.shipment_advice_out, picking2)
+        self.assertTrue(self.shipment_advice_out.planned_picking_order_ids)
+
+        # test that manual changes to order are preserved
+        picking.with_context(
+            active_shipment_advice_id=self.shipment_advice_out.id
+        ).sequence_in_shipment_advice = 20
+        picking2.with_context(
+            active_shipment_advice_id=self.shipment_advice_out.id
+        ).sequence_in_shipment_advice = 0
+
+        shipment_advice_out_first_picking = (
+            self.env["stock.picking"]
+            .with_context(active_shipment_advice_id=self.shipment_advice_out.id)
+            .search(
+                [("move_ids.shipment_advice_id", "=", self.shipment_advice_out.id)],
+            )
+        )
+        self.assertEqual(shipment_advice_out_first_picking[0], picking2)
+
+        # test stock.picking search count don't raise error
+        self.env["stock.picking"].with_context(
+            active_shipment_advice_id=self.shipment_advice_out.id
+        ).search_count(
+            [("move_ids.shipment_advice_id", "=", self.shipment_advice_out.id)]
+        )
+
+        # test the same is reflected when searching at stock.move level
+        shipment_advice_out_first_move = (
+            self.env["stock.move"]
+            .with_context(active_shipment_advice_id=self.shipment_advice_out.id)
+            .search(
+                [("shipment_advice_id", "=", self.shipment_advice_out.id)],
+            )
+        )
+
+        self.assertEqual(shipment_advice_out_first_move.picking_id[0], picking2)
+
+        # test stock.move search count don't raise error
+        self.env["stock.move"].with_context(
+            active_shipment_advice_id=self.shipment_advice_out.id
+        ).search_count([("shipment_advice_id", "=", self.shipment_advice_out.id)])
+
+        # test same picking planned in different shipment advices might have different
+        # order
+        shipment_advice_out2 = self.env["shipment.advice"].create(
+            {"shipment_type": "outgoing"}
+        )
+        self.plan_records_in_shipment(shipment_advice_out2, picking)
+        self.assertTrue(
+            picking.with_context(
+                active_shipment_advice_id=self.shipment_advice_out.id
+            ).sequence_in_shipment_advice
+            != picking.with_context(
+                active_shipment_advice_id=shipment_advice_out2.id
+            ).sequence_in_shipment_advice
+        )
 
     def test_shipment_advice_plan_move(self):
         picking = self.move_product_out1.picking_id
@@ -30,3 +98,31 @@ class TestShipmentAdvicePlan(Common):
             wiz.shipment_advice_id.planned_move_ids, self.move_product_out1
         )
         self.assertEqual(wiz.shipment_advice_id.planned_moves_count, 1)
+
+    def test_shipment_advice_plan_picking_order_sorted(self):
+        """Verify that planned_picking_ids sorted by sequence_in_shipment_advice
+        (as done in qweb templates) respects the user-defined order."""
+        picking1 = self.move_product_out1.picking_id
+        picking2 = self._create_distinct_picking(
+            self.picking_type_out, self.product_out2, 5
+        )
+
+        self.plan_records_in_shipment(self.shipment_advice_out, picking1)
+        self.plan_records_in_shipment(self.shipment_advice_out, picking2)
+
+        picking2.with_context(
+            active_shipment_advice_id=self.shipment_advice_out.id
+        ).sequence_in_shipment_advice = 0
+        picking1.with_context(
+            active_shipment_advice_id=self.shipment_advice_out.id
+        ).sequence_in_shipment_advice = 10
+
+        sa = self.shipment_advice_out
+        sorted_pickings = sa.planned_picking_ids.sorted(
+            lambda p: p.with_context(
+                active_shipment_advice_id=sa.id
+            ).sequence_in_shipment_advice
+        )
+
+        self.assertEqual(sorted_pickings[0], picking2)
+        self.assertEqual(sorted_pickings[1], picking1)

--- a/shipment_advice/tests/test_shipment_advice_stock_user.py
+++ b/shipment_advice/tests/test_shipment_advice_stock_user.py
@@ -12,7 +12,9 @@ class TestShipmentAdviceStockUser(Common):
 
     def test_shipment_advice_button_open_planned_pickings(self):
         shipment_advice = self.shipment_advice_out.with_user(self.stock_user)
-        action = shipment_advice.button_open_planned_pickings()
+        action = shipment_advice.with_context(
+            allowed_company_ids=self.env.company.ids
+        ).button_open_planned_pickings()
         self.assertEqual(action["name"], "Transfers")
 
     def test_shipment_advice_button_open_planned_moves(self):

--- a/shipment_advice/views/stock_move.xml
+++ b/shipment_advice/views/stock_move.xml
@@ -27,6 +27,19 @@
             </group>
         </field>
     </record>
+    <record id="view_picking_move_tree" model="ir.ui.view">
+        <field name="name">stock.move.tree.sorting</field>
+        <field name="model">stock.move</field>
+        <field name="inherit_id" ref="stock.view_picking_move_tree" />
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <field name="product_id" position="after">
+                <field name="picking_id" invisible="1" />
+                <field name="reference" />
+            </field>
+        </field>
+    </record>
+
     <record id="wizard_plan_shipment_move_action" model="ir.actions.act_window">
         <field name="name">Plan in shipment</field>
         <field name="type">ir.actions.act_window</field>

--- a/shipment_advice/views/stock_picking.xml
+++ b/shipment_advice/views/stock_picking.xml
@@ -56,7 +56,20 @@
             </field>
         </field>
     </record>
-    <record id="view_picking_internal_search" model="ir.ui.view">
+    <record id="vpicktree_planned_shipment_advice_order" model="ir.ui.view">
+        <field name="name">stock.picking.tree.inherit</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="shipment_advice.vpicktree" />
+        <field name="mode">primary</field>
+        <field name="priority">101</field>
+        <field name="arch" type="xml">
+            <field name="name" position="before">
+                <field name="sequence_in_shipment_advice" widget="handle" />
+            </field>
+        </field>
+    </record>
+
+   <record id="view_picking_internal_search" model="ir.ui.view">
         <field name="name">stock.picking.search.inherit</field>
         <field name="model">stock.picking</field>
         <field name="inherit_id" ref="stock.view_picking_internal_search" />
@@ -124,6 +137,7 @@
             </tree>
         </field>
     </record>
+
     <record id="wizard_plan_shipment_picking_action" model="ir.actions.act_window">
         <field name="name">Plan in shipment</field>
         <field name="type">ir.actions.act_window</field>


### PR DESCRIPTION
This feature enables manual sorting of planned pickings within a shipment advice. Planned moves are then automatically displayed according to the defined move sequence. The order is also respected when rendering shipment advice report.

Inspired by https://github.com/OCA/stock-logistics-transport/issues/206#issuecomment-3749843300
@BinhexTeam T16102