### PR TITLE
[IMP] shipment_advice_planner_toursolver: support advanced settings

### DIFF
--- a/shipment_advice_planner_toursolver/models/toursolver_backend.py
+++ b/shipment_advice_planner_toursolver/models/toursolver_backend.py
@@ -83,6 +83,9 @@ class TourSolverBackend(models.Model):
         default=10,
         required=True,
     )
+    advanced_settings = fields.Char(
+        default="BalancingCost=1,CostsWeights=balancing:5,BalancingValue=WORKTIME"
+    )
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -120,6 +123,7 @@ class TourSolverBackend(models.Model):
 
     def _get_loading_duration_formatted(self):
         h, m = divmod(self.loading_duration, 60)
+        # flake8: noqa: E231
         return f"{h:02d}:{m:02d}:00"
 
     def _get_backend_default_options(self):

--- a/shipment_advice_planner_toursolver/models/toursolver_task.py
+++ b/shipment_advice_planner_toursolver/models/toursolver_task.py
@@ -375,6 +375,9 @@ class ToursolverTask(models.Model):
                 )
             }
         )
+        if self.toursolver_backend_id.advanced_settings:
+            advanced_settings = self.toursolver_backend_id.advanced_settings.split(",")
+            res.update({"advancedSettings": advanced_settings})
         return res
 
     def button_check_status(self):

--- a/shipment_advice_planner_toursolver/views/toursolver_backend.xml
+++ b/shipment_advice_planner_toursolver/views/toursolver_backend.xml
@@ -77,6 +77,9 @@
                                 to learn more.<br />
                             </p>
                             <field name="rqst_options_properties" />
+                           <group>
+                               <field name="advanced_settings" />
+                           </group>
                         </page>
                         <page
                             string="Request Orders Properties"


### PR DESCRIPTION
Add configurable advancedSettings support to TourSolver requests

The backend now exposes an `advanced_settings` field with default balancing configuration values, and automatically injects them into the generated JSON request options