### PR TITLE
[FIX] stock_dock: multi company compatibility

### DIFF
--- a/stock_dock/demo/stock_dock.xml
+++ b/stock_dock/demo/stock_dock.xml
@@ -5,5 +5,6 @@
     <record id="stock_dock_demo" model="stock.dock">
         <field name="name">Dock 01</field>
         <field name="barcode">DOCK01</field>
+        <field name="warehouse_id" ref="stock.warehouse0" />
     </record>
 </odoo>

--- a/stock_dock/models/stock_dock.py
+++ b/stock_dock/models/stock_dock.py
@@ -7,6 +7,7 @@ from odoo import fields, models
 class StockDock(models.Model):
     _name = "stock.dock"
     _description = "Dock, used by trucks to load/unload goods"
+    _check_company_auto = True
 
     name = fields.Char(required=True)
     barcode = fields.Char()
@@ -17,17 +18,12 @@ class StockDock(models.Model):
         string="Warehouse",
         required=True,
         check_company=True,
-        default=lambda self: self._default_warehouse_id(),
     )
     company_id = fields.Many2one(
         comodel_name="res.company",
         string="Company",
-        related="warehouse_id.company_id",
+        default=lambda self: self.env.company,
         readonly=True,
-        store=True,
         index=True,
+        required=True,
     )
-
-    def _default_warehouse_id(self):
-        wh = self.env.ref("stock.warehouse0", raise_if_not_found=False)
-        return wh.id or False


### PR DESCRIPTION
If warehouse_id use `check_company=True`, company_id should not be related to this (warehouse_id).

This causes us to be unable to create stock.dock record for a company other than the one related to stock.warehouse0, even though we have changed the current company in the systray with another company.