### PR TITLE
[17.0][FIX] tms: delegate schedule_meeting on driver form

### DIFF
--- a/tms/models/tms_driver.py
+++ b/tms/models/tms_driver.py
@@ -113,3 +113,6 @@ class TmsDriver(models.Model):
     def geo_localize(self):
         res = super().geo_localize()
         return res
+
+    def schedule_meeting(self):
+        return self.partner_id.schedule_meeting()

--- a/tms/tests/test_tms_driver.py
+++ b/tms/tests/test_tms_driver.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from odoo.tests.common import TransactionCase
 
 
@@ -28,8 +30,6 @@ class TestTmsDriver(TransactionCase):
         )
 
     def test_driver_creation(self):
-        self.driver._default_stage_id()
-
         self.assertTrue(self.driver, "Driver wasn't created successfully")
         self.assertEqual(
             self.driver.name, "Test Driver", "Driver name should be 'Test Driver'"
@@ -59,3 +59,42 @@ class TestTmsDriver(TransactionCase):
         self.assertTrue(
             self.driver.stage_id, "Driver stage should be correctly assigned"
         )
+
+    def test_driver_default_is_active(self):
+        driver = self.env["tms.driver"].create({"name": "Active Driver"})
+        self.assertTrue(driver.is_active)
+        self.assertFalse(driver.is_training)
+
+    def test_default_stage_id(self):
+        stage_id = self.env["tms.driver"]._default_stage_id()
+        self.assertEqual(stage_id, self.stage.id)
+
+    def test_read_group_stage_ids(self):
+        stages = self.env["tms.driver"]._read_group_stage_ids(
+            self.env["tms.stage"], [], "sequence"
+        )
+        self.assertIn(self.stage, stages)
+        self.assertTrue(all(stage.stage_type == "driver" for stage in stages))
+
+    def test_schedule_meeting_delegates_to_partner(self):
+        expected_action = {
+            "type": "ir.actions.act_window",
+            "res_model": "calendar.event",
+        }
+        partner_model = type(self.env["res.partner"])
+        with patch.object(
+            partner_model,
+            "schedule_meeting",
+            lambda self: expected_action,
+            create=True,
+        ):
+            action = self.driver.schedule_meeting()
+        self.assertEqual(action, expected_action)
+
+    def test_schedule_meeting_with_calendar(self):
+        if not hasattr(type(self.driver.partner_id), "schedule_meeting"):
+            self.skipTest("calendar module is not installed")
+        action = self.driver.schedule_meeting()
+        self.assertEqual(action.get("res_model"), "calendar.event")
+        partner_ids = action.get("context", {}).get("default_partner_ids", [])
+        self.assertIn(self.driver.partner_id.id, partner_ids)


### PR DESCRIPTION
## Summary
- Add `schedule_meeting` on `tms.driver` that delegates to the linked `res.partner`.
- Fixes the Meetings stat button on the driver form when Calendar is installed (inherits partner form view).
- Add a regression test that runs when Calendar is available.

Fixes #216

## Test plan
- [x] Install TMS and Calendar
- [x] Open a driver form and click the Meetings stat button
- [x] Confirm the calendar view opens instead of an RPC AttributeError
- [x] Run TMS tests (`test_schedule_meeting` skips if Calendar is not installed)


Made with [Cursor](https://cursor.com)