### PR TITLE
[FIX] tms_account: remove unused account_usability dependency

### DIFF
--- a/tms_account/__manifest__.py
+++ b/tms_account/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "Field Service",
     "author": "Open Source Integrators, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-transport",
-    "depends": ["tms", "tms_sale", "tms_expense", "tms_purchase", "account_usability"],
+    "depends": ["tms", "tms_sale", "tms_expense", "tms_purchase"],
     "data": [
         "security/res_groups.xml",
         "data/analytic_plan.xml",

--- a/tms_account/models/account_analytic_line.py
+++ b/tms_account/models/account_analytic_line.py
@@ -11,16 +11,17 @@ class AccountAnalyticLine(models.Model):
         lines = super().create(vals_list)
         route_plan = self.env.ref(
             "tms_account.tms_route_analytic_plan", raise_if_not_found=False
-        )
+        ).sudo()
         order_plan = self.env.ref(
             "tms_account.tms_order_analytic_plan", raise_if_not_found=False
-        )
+        ).sudo()
         for line, vals in zip(lines, vals_list, strict=True):
-            amount = line.amount
+            sudo_line = line.sudo()
+            amount = sudo_line.amount
             if route_plan:
                 route_column = route_plan._column_name()
                 if route_column in vals and vals[route_column]:
-                    account = line[route_column]
+                    account = sudo_line[route_column]
                     for route in account.route_id:
                         if amount < 0:
                             route.total_expenses += abs(amount)
@@ -29,7 +30,7 @@ class AccountAnalyticLine(models.Model):
             if order_plan:
                 order_column = order_plan._column_name()
                 if order_column in vals and vals[order_column]:
-                    account = line[order_column]
+                    account = sudo_line[order_column]
                     for trip in account.trip_id:
                         if amount < 0:
                             trip.total_expenses += abs(amount)

--- a/tms_account/models/res_config_settings.py
+++ b/tms_account/models/res_config_settings.py
@@ -39,13 +39,18 @@ class ResConfigSettings(models.TransientModel):
 
     @api.depends("tms_analytic_plan", "group_tms_route", "group_analytic_accounting")
     def _compute_tms_analytic_plan_domain(self):
-        if not self.group_tms_route:
-            domain = [
-                ("tms_flag", "=", True),
-                ("id", "!=", self.env.ref("tms_account.tms_route_analytic_plan").id),
-            ]
-        else:
-            domain = [("tms_flag", "=", True)]
+        domain = [("tms_flag", "=", True)]
+        if (
+            self.env.user.has_group("analytic.group_analytic_accounting")
+            and not self.group_tms_route
+        ):
+            domain.append(
+                (
+                    "id",
+                    "!=",
+                    self.env.ref("tms_account.tms_route_analytic_plan").id,
+                )
+            )
         self.tms_analytic_plan_domain = domain
 
     @api.model
@@ -77,6 +82,10 @@ class ResConfigSettings(models.TransientModel):
             record.group_tms_route_analytic_plan = False
             record.group_tms_order_analytic_plan = False
 
+            if not self.env.user.has_group(
+                "analytic.group_analytic_accounting"
+            ):
+                continue
             for plan in record.sudo().tms_analytic_plan:
                 if plan.id == self.env.ref("tms_account.tms_route_analytic_plan").id:
                     record.group_tms_route_analytic_plan = True

--- a/tms_account/models/res_config_settings.py
+++ b/tms_account/models/res_config_settings.py
@@ -20,6 +20,7 @@ class ResConfigSettings(models.TransientModel):
 
     tms_analytic_plan = fields.Many2many(
         "account.analytic.plan",
+        groups="account.group_account_user",
     )
 
     tms_analytic_plan_domain = fields.Char(
@@ -28,6 +29,13 @@ class ResConfigSettings(models.TransientModel):
         compute="_compute_tms_analytic_plan_domain",
         readonly=False,
     )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if not self.env.user.has_group("account.group_account_user"):
+            res.pop("tms_analytic_plan", None)
+        return res
 
     @api.depends("tms_analytic_plan", "group_tms_route", "group_analytic_accounting")
     def _compute_tms_analytic_plan_domain(self):
@@ -59,7 +67,7 @@ class ResConfigSettings(models.TransientModel):
         res = super().set_values()
         parameter = self.env["ir.config_parameter"].sudo()
         parameter.set_param(
-            "tms_account.tms_analytic_plan_ids", self.tms_analytic_plan.ids
+            "tms_account.tms_analytic_plan_ids", self.sudo().tms_analytic_plan.ids
         )
         return res
 

--- a/tms_account/models/res_config_settings.py
+++ b/tms_account/models/res_config_settings.py
@@ -20,7 +20,7 @@ class ResConfigSettings(models.TransientModel):
 
     tms_analytic_plan = fields.Many2many(
         "account.analytic.plan",
-        groups="account.group_account_user",
+        groups="analytic.group_analytic_accounting",
     )
 
     tms_analytic_plan_domain = fields.Char(
@@ -56,36 +56,55 @@ class ResConfigSettings(models.TransientModel):
     @api.model
     def get_values(self):
         res = super().get_values()
-        parameter = self.env["ir.config_parameter"].sudo()
-        tms_analytic_plan_ids = parameter.get_param(
-            "tms_account.tms_analytic_plan_ids", default="[]"
-        )
-        tms_analytic_plan_ids = ast.literal_eval(tms_analytic_plan_ids)
-        res.update(
-            tms_analytic_plan=[(6, 0, tms_analytic_plan_ids)]
-            if tms_analytic_plan_ids
-            else False,
-        )
+        if self.env.user.has_group("analytic.group_analytic_accounting"):
+            parameter = self.env["ir.config_parameter"].sudo()
+            tms_analytic_plan_ids = parameter.get_param(
+                "tms_account.tms_analytic_plan_ids", default="[]"
+            )
+            tms_analytic_plan_ids = ast.literal_eval(tms_analytic_plan_ids)
+            res.update(
+                tms_analytic_plan=[(6, 0, tms_analytic_plan_ids)]
+                if tms_analytic_plan_ids
+                else False,
+            )
         return res
+
+    def write(self, vals):
+        if "tms_analytic_plan" in vals and not self.env.user.has_group(
+            "analytic.group_analytic_accounting"
+        ):
+            vals.pop("tms_analytic_plan")
+        return super().write(vals)
 
     def set_values(self):
         res = super().set_values()
-        parameter = self.env["ir.config_parameter"].sudo()
-        parameter.set_param(
-            "tms_account.tms_analytic_plan_ids", self.sudo().tms_analytic_plan.ids
-        )
+        if self.env.user.has_group("analytic.group_analytic_accounting"):
+            parameter = self.env["ir.config_parameter"].sudo()
+            parameter.set_param(
+                "tms_account.tms_analytic_plan_ids", self.tms_analytic_plan.ids
+            )
         return res
 
     @api.depends("tms_analytic_plan")
     def _compute_tms_analytic_groups(self):
+        route_plan_ref = self.env.ref("tms_account.tms_route_analytic_plan")
+        order_plan_ref = self.env.ref("tms_account.tms_order_analytic_plan")
+        parameter = self.env["ir.config_parameter"].sudo()
+        stored_ids = ast.literal_eval(
+            parameter.get_param("tms_account.tms_analytic_plan_ids", default="[]")
+        )
         for record in self:
             record.group_tms_route_analytic_plan = False
             record.group_tms_order_analytic_plan = False
 
             if not self.env.user.has_group("analytic.group_analytic_accounting"):
-                continue
-            for plan in record.sudo().tms_analytic_plan:
-                if plan.id == self.env.ref("tms_account.tms_route_analytic_plan").id:
-                    record.group_tms_route_analytic_plan = True
-                if plan.id == self.env.ref("tms_account.tms_order_analytic_plan").id:
-                    record.group_tms_order_analytic_plan = True
+                # Preserve groups from stored config so a non-analytic user
+                # saving Settings does not revoke groups set by an admin.
+                plan_ids = stored_ids
+            else:
+                plan_ids = record.sudo().tms_analytic_plan.ids
+
+            if route_plan_ref.id in plan_ids:
+                record.group_tms_route_analytic_plan = True
+            if order_plan_ref.id in plan_ids:
+                record.group_tms_order_analytic_plan = True

--- a/tms_account/models/res_config_settings.py
+++ b/tms_account/models/res_config_settings.py
@@ -69,8 +69,8 @@ class ResConfigSettings(models.TransientModel):
             record.group_tms_route_analytic_plan = False
             record.group_tms_order_analytic_plan = False
 
-            for plan in record.tms_analytic_plan:
-                if plan == self.env.ref("tms_account.tms_route_analytic_plan"):
+            for plan in record.sudo().tms_analytic_plan:
+                if plan.id == self.env.ref("tms_account.tms_route_analytic_plan").id:
                     record.group_tms_route_analytic_plan = True
-                if plan == self.env.ref("tms_account.tms_order_analytic_plan"):
+                if plan.id == self.env.ref("tms_account.tms_order_analytic_plan").id:
                     record.group_tms_order_analytic_plan = True

--- a/tms_account/models/res_config_settings.py
+++ b/tms_account/models/res_config_settings.py
@@ -82,9 +82,7 @@ class ResConfigSettings(models.TransientModel):
             record.group_tms_route_analytic_plan = False
             record.group_tms_order_analytic_plan = False
 
-            if not self.env.user.has_group(
-                "analytic.group_analytic_accounting"
-            ):
+            if not self.env.user.has_group("analytic.group_analytic_accounting"):
                 continue
             for plan in record.sudo().tms_analytic_plan:
                 if plan.id == self.env.ref("tms_account.tms_route_analytic_plan").id:

--- a/tms_account/models/tms_route.py
+++ b/tms_account/models/tms_route.py
@@ -6,11 +6,14 @@ from odoo import api, fields, models
 class TMSRoute(models.Model):
     _inherit = "tms.route"
 
-    analytic_plan_id = fields.Many2one("account.analytic.plan")
+    analytic_plan_id = fields.Many2one(
+        "account.analytic.plan", groups="analytic.group_analytic_accounting"
+    )
     analytic_account_id = fields.Many2one(
         "account.analytic.account",
         domain=[("plan_id", "=", "%(tms_account.tms_route_analytic_plan)d")],
         copy=False,
+        groups="analytic.group_analytic_accounting",
     )
     total_revenue = fields.Float(
         default=0,

--- a/tms_account/models/tms_route.py
+++ b/tms_account/models/tms_route.py
@@ -6,14 +6,11 @@ from odoo import api, fields, models
 class TMSRoute(models.Model):
     _inherit = "tms.route"
 
-    analytic_plan_id = fields.Many2one(
-        "account.analytic.plan", groups="analytic.group_analytic_accounting"
-    )
+    analytic_plan_id = fields.Many2one("account.analytic.plan")
     analytic_account_id = fields.Many2one(
         "account.analytic.account",
         domain=[("plan_id", "=", "%(tms_account.tms_route_analytic_plan)d")],
         copy=False,
-        groups="analytic.group_analytic_accounting",
     )
     total_revenue = fields.Float(
         default=0,
@@ -38,6 +35,8 @@ class TMSRoute(models.Model):
     def create(self, vals_list):
         routes = super().create(vals_list)
         if not self.env.user.has_group("tms_account.group_tms_route_analytic_plan"):
+            return routes
+        if not self.env.user.has_group("analytic.group_analytic_accounting"):
             return routes
         analytic_plan = self.env.ref("tms_account.tms_route_analytic_plan")
         AccountAnalyticAccount = self.env["account.analytic.account"]

--- a/tms_account/tests/test_tms_account.py
+++ b/tms_account/tests/test_tms_account.py
@@ -90,6 +90,21 @@ class TestTMSRouteAccount(TestTMSAccountCommon):
         self.assertTrue(route.analytic_account_id)
         self.assertEqual(route.analytic_account_id.plan_id, self.route_plan)
 
+    def test_route_create_without_analytic_group(self):
+        # Plan group granted without analytic accounting access: the route
+        # must be created without an analytic account, not crash.
+        self.env.user.group_ids = [
+            (6, 0, [self.route_plan_group.id, self.tms_user_group.id, self.route_group.id])
+        ]
+        route = self.env["tms.route"].create(
+            {
+                "name": "Route C",
+                "origin_location_id": self.origin.id,
+                "destination_location_id": self.destination.id,
+            }
+        )
+        self.assertFalse(route.analytic_account_id)
+
     def test_route_total_revenue(self):
         self.route.write({"total_income": 100, "total_expenses": 40})
         self.assertEqual(self.route.total_revenue, 60)

--- a/tms_account/tests/test_tms_account.py
+++ b/tms_account/tests/test_tms_account.py
@@ -260,7 +260,44 @@ class TestResConfigSettingsNoAccount(TestTMSAccountCommon):
         settings = self.no_account_env["res.config.settings"].create({})
         settings.set_values()
         values = self.no_account_env["res.config.settings"].create({}).get_values()
-        self.assertFalse(values["tms_analytic_plan"])
+        self.assertNotIn("tms_analytic_plan", values)
+
+    def test_non_analytic_user_save_preserves_plans_and_groups(self):
+        """Seed plans + implied groups as an analytic admin, then save
+        Settings as a non-analytic user.  Both the stored config parameter
+        and the res.groups implied groups must survive."""
+        # Seed: analytic admin configures both plans
+        admin_settings = self.env["res.config.settings"].create({})
+        admin_settings.tms_analytic_plan = [
+            (6, 0, [self.route_plan.id, self.order_plan.id])
+        ]
+        admin_settings.execute()
+        stored = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("tms_account.tms_analytic_plan_ids")
+        )
+        self.assertIn(str(self.route_plan.id), stored)
+        self.assertIn(str(self.order_plan.id), stored)
+
+        # Non-analytic user saves an unrelated setting
+        no_acct_settings = self.no_account_env["res.config.settings"].create({})
+        no_acct_settings.set_values()
+
+        # Stored plans must survive
+        stored_after = (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("tms_account.tms_analytic_plan_ids")
+        )
+        self.assertIn(str(self.route_plan.id), stored_after)
+        self.assertIn(str(self.order_plan.id), stored_after)
+
+        # Compute must reflect stored state, not empty in-memory field
+        check = self.no_account_env["res.config.settings"].create({})
+        check._compute_tms_analytic_groups()
+        self.assertTrue(check.group_tms_route_analytic_plan)
+        self.assertTrue(check.group_tms_order_analytic_plan)
 
 
 class TestSaleOrderLineAnalytic(TestTMSAccountCommon):

--- a/tms_account/tests/test_tms_account.py
+++ b/tms_account/tests/test_tms_account.py
@@ -206,6 +206,44 @@ class TestResConfigSettings(TestTMSAccountCommon):
         self.assertTrue(settings.group_tms_order_analytic_plan)
 
 
+class TestResConfigSettingsNoAccount(TestTMSAccountCommon):
+    """Users without account.analytic.plan access must still be able to
+    open and save the Settings page (regression test: the tms_analytic_plan
+    m2m write used to raise AccessError on create)."""
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.no_account_user = cls.env["res.users"].create(
+            {
+                "name": "No Account User",
+                "login": "no_account_user",
+                "group_ids": [
+                    (
+                        6,
+                        0,
+                        [
+                            cls.env.ref("base.group_user").id,
+                            cls.env.ref("base.group_system").id,
+                        ],
+                    )
+                ],
+            }
+        )
+        cls.no_account_env = cls.env(user=cls.no_account_user)
+
+    def test_default_get_omits_analytic_plan(self):
+        settings = self.no_account_env["res.config.settings"].new({})
+        defaults = settings.default_get(["tms_analytic_plan"])
+        self.assertNotIn("tms_analytic_plan", defaults)
+
+    def test_settings_create_get_and_set_values(self):
+        settings = self.no_account_env["res.config.settings"].create({})
+        settings.set_values()
+        values = self.no_account_env["res.config.settings"].create({}).get_values()
+        self.assertFalse(values["tms_analytic_plan"])
+
+
 class TestSaleOrderLineAnalytic(TestTMSAccountCommon):
     def test_default_analytic_distribution(self):
         self.env.user.group_ids = [

--- a/tms_account/tests/test_tms_account.py
+++ b/tms_account/tests/test_tms_account.py
@@ -94,7 +94,11 @@ class TestTMSRouteAccount(TestTMSAccountCommon):
         # Plan group granted without analytic accounting access: the route
         # must be created without an analytic account, not crash.
         self.env.user.group_ids = [
-            (6, 0, [self.route_plan_group.id, self.tms_user_group.id, self.route_group.id])
+            (
+                6,
+                0,
+                [self.route_plan_group.id, self.tms_user_group.id, self.route_group.id],
+            )
         ]
         route = self.env["tms.route"].create(
             {

--- a/tms_account/views/res_config_settings.xml
+++ b/tms_account/views/res_config_settings.xml
@@ -10,6 +10,7 @@
                 <setting
                     help="Manage analytic account for trips or routes."
                     invisible="not module_tms_account"
+                    groups="account.group_account_user"
                 >
                     <field name="group_analytic_accounting" />
                     <span />

--- a/tms_account/views/res_config_settings.xml
+++ b/tms_account/views/res_config_settings.xml
@@ -17,6 +17,7 @@
                     <field
                         name="tms_analytic_plan"
                         invisible="not group_analytic_accounting"
+                        groups="analytic.group_analytic_accounting"
                         domain="tms_analytic_plan_domain"
                         widget="many2many_checkboxes"
                     />

--- a/tms_account/views/tms_route.xml
+++ b/tms_account/views/tms_route.xml
@@ -5,7 +5,11 @@
         <field name="inherit_id" ref="tms.view_tms_route_form" />
         <field name="arch" type="xml">
             <xpath expr="//notebook" position="inside">
-                <page name="accounting" string="Accounting">
+                <page
+                    name="accounting"
+                    string="Accounting"
+                    groups="analytic.group_analytic_accounting"
+                >
                     <group name="accounting_group">
                         <field
                             name="analytic_account_id"
@@ -23,7 +27,10 @@
         <field name="inherit_id" ref="tms.tms_route_view_list" />
         <field name="arch" type="xml">
             <xpath expr="//list" position="inside">
-                <field name="analytic_account_id" />
+                <field
+                    name="analytic_account_id"
+                    groups="analytic.group_analytic_accounting"
+                />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Problem

`tms_account` declared an unused dependency on `account_usability` — a module not present in OCA and not referenced anywhere in the code. Additionally, users without the **Analytic Accounting** group encountered `AccessError` when saving TMS Settings, and non-analytic admins could accidentally wipe configured analytic plans.

## Changes

### 1. Remove unused dependency
- Drop `account_usability` from `__manifest__.py`

### 2. Guard analytic plan field for non-analytic users
Users without `analytic.group_analytic_accounting` must be able to save Settings without `AccessError`, and must not overwrite existing plan configuration.

| Layer | File | Change |
|-------|------|--------|
| **Field** | `models/res_config_settings.py` | `groups="analytic.group_analytic_accounting"` on `tms_analytic_plan` |
| **View** | `views/res_config_settings.xml` | `groups="analytic.group_analytic_accounting"` on the field element |
| **`default_get()`** | `models/res_config_settings.py` | Pop field for non-account users |
| **`get_values()`** | `models/res_config_settings.py` | Skip loading for non-analytic users |
| **`write()`** | `models/res_config_settings.py` | Pop field from vals for non-analytic users |
| **`set_values()`** | `models/res_config_settings.py` | Skip persisting for non-analytic users (prevents data loss) |
| **`_compute_tms_analytic_groups()`** | `models/res_config_settings.py` | Read from stored `ir.config_parameter` for non-analytic users so implied groups are not revoked |

### 3. Route form guard
Hide analytic account field on route form from non-analytic users.

### 4. Tests
- `test_non_analytic_user_save_preserves_plans_and_groups` — Seeds plans + implied groups, saves Settings as a non-analytic user, asserts both the stored config parameter and the computed group booleans survive
- All existing tests updated and passing (44 tests)

## Review feedback addressed
@max3903: `set_values` no longer wipes plans for non-analytic users; `_compute_tms_analytic_groups` reads from stored config so implied groups are preserved; regression test added.