### PR TITLE
[FIX] tms: fix smart buttons on driver form for delegation inheritance

### DIFF
--- a/tms/models/tms_driver.py
+++ b/tms/models/tms_driver.py
@@ -117,23 +117,3 @@ class TmsDriver(models.Model):
 
     def action_view_stock_serial(self):
         return self.partner_id.action_view_stock_serial()
-
-    def action_view_purchase_orders(self):
-        self.ensure_one()
-        action = self.env["ir.actions.act_window"]._for_xml_id(
-            "purchase.act_res_partner_2_purchase_order"
-        )
-        action["context"] = {
-            "search_default_partner_id": self.partner_id.id,
-            "default_partner_id": self.partner_id.id,
-        }
-        return action
-
-    def action_view_sale_orders(self):
-        self.ensure_one()
-        action = self.env["ir.actions.act_window"]._for_xml_id(
-            "sale.act_res_partner_2_sale_order"
-        )
-        action["context"] = {"default_partner_id": self.partner_id.id}
-        action["domain"] = [("partner_id", "child_of", self.partner_id.id)]
-        return action

--- a/tms/models/tms_driver.py
+++ b/tms/models/tms_driver.py
@@ -92,28 +92,48 @@ class TmsDriver(models.Model):
     # Inherited actions from res_partner
 
     def create_company(self):
-        res = super().create_company()
-        return res
+        return self.partner_id.create_company()
 
     def action_open_employees(self):
-        res = super().action_open_employees()
-        return res
+        return self.partner_id.action_open_employees()
 
     def open_commercial_entity(self):
-        res = super().open_commercial_entity()
-        return res
+        return self.partner_id.open_commercial_entity()
 
     def phone_action_blacklist_remove(self):
-        res = super().phone_action_blacklist_remove()
-        return res
+        return self.partner_id.phone_action_blacklist_remove()
 
     def mail_action_blacklist_remove(self):
-        res = super().mail_action_blacklist_remove()
-        return res
+        return self.partner_id.mail_action_blacklist_remove()
 
     def geo_localize(self):
-        res = super().geo_localize()
-        return res
+        return self.partner_id.geo_localize()
 
     def schedule_meeting(self):
         return self.partner_id.schedule_meeting()
+
+    def action_view_partner_invoices(self):
+        return self.partner_id.action_view_partner_invoices()
+
+    def action_view_stock_serial(self):
+        return self.partner_id.action_view_stock_serial()
+
+    def action_view_purchase_orders(self):
+        self.ensure_one()
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "purchase.act_res_partner_2_purchase_order"
+        )
+        action["context"] = {
+            "search_default_partner_id": self.partner_id.id,
+            "default_partner_id": self.partner_id.id,
+        }
+        return action
+
+    def action_view_sale_orders(self):
+        self.ensure_one()
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "sale.act_res_partner_2_sale_order"
+        )
+        action["context"] = {"default_partner_id": self.partner_id.id}
+        action["domain"] = [("partner_id", "child_of", self.partner_id.id)]
+        return action

--- a/tms/tests/test_tms_driver.py
+++ b/tms/tests/test_tms_driver.py
@@ -88,69 +88,12 @@ class TestTmsDriver(TransactionCase):
         action = self.driver.schedule_meeting()
         self.assertEqual(action.get("res_model"), "calendar.event")
 
-    def _partner_method_available(self, method_name):
-        return hasattr(type(self.driver.partner_id), method_name)
-
     def test_create_company_delegates_to_partner(self):
-        if not self._partner_method_available("create_company"):
-            self.skipTest("create_company not available on res.partner")
         self.driver.create_company()
 
-    def test_action_open_employees_delegates_to_partner(self):
-        if not self._partner_method_available("action_open_employees"):
-            self.skipTest("action_open_employees not available on res.partner")
-        action = self.driver.action_open_employees()
-        self.assertEqual(action.get("res_model"), "hr.employee")
-
     def test_open_commercial_entity_delegates_to_partner(self):
-        if not self._partner_method_available("open_commercial_entity"):
-            self.skipTest("open_commercial_entity not available on res.partner")
         action = self.driver.open_commercial_entity()
         self.assertEqual(action.get("res_model"), "res.partner")
 
-    def test_blacklist_remove_delegates_to_partner(self):
-        if not self._partner_method_available("phone_action_blacklist_remove"):
-            self.skipTest("blacklist methods not available on res.partner")
-        self.driver.phone_action_blacklist_remove()
-        self.driver.mail_action_blacklist_remove()
-
     def test_geo_localize_delegates_to_partner(self):
-        if not self._partner_method_available("geo_localize"):
-            self.skipTest("geo_localize not available on res.partner")
         self.driver.geo_localize()
-
-    def test_action_view_partner_invoices_delegates_to_partner(self):
-        if not self._partner_method_available("action_view_partner_invoices"):
-            self.skipTest("action_view_partner_invoices not available")
-        action = self.driver.action_view_partner_invoices()
-        self.assertEqual(action.get("res_model"), "account.move")
-
-    def test_action_view_stock_serial_delegates_to_partner(self):
-        if not self._partner_method_available("action_view_stock_serial"):
-            self.skipTest("stock module is not installed")
-        action = self.driver.action_view_stock_serial()
-        self.assertEqual(action.get("res_model"), "stock.lot")
-
-    def test_action_view_purchase_orders_uses_partner_id(self):
-        try:
-            action = self.driver.action_view_purchase_orders()
-        except Exception:
-            self.skipTest("purchase module is not installed")
-        self.assertEqual(action.get("res_model"), "purchase.order")
-        self.assertEqual(
-            action.get("context", {}).get("search_default_partner_id"),
-            self.driver.partner_id.id,
-            "Purchase search should use the driver's partner id, not driver id",
-        )
-
-    def test_action_view_sale_orders_uses_partner_id(self):
-        try:
-            action = self.driver.action_view_sale_orders()
-        except Exception:
-            self.skipTest("sale module is not installed")
-        self.assertEqual(action.get("res_model"), "sale.order")
-        self.assertEqual(
-            action.get("context", {}).get("default_partner_id"),
-            self.driver.partner_id.id,
-            "Sale order should default to the driver's partner id, not driver id",
-        )

--- a/tms/tests/test_tms_driver.py
+++ b/tms/tests/test_tms_driver.py
@@ -87,3 +87,70 @@ class TestTmsDriver(TransactionCase):
             self.skipTest("calendar module is not installed")
         action = self.driver.schedule_meeting()
         self.assertEqual(action.get("res_model"), "calendar.event")
+
+    def _partner_method_available(self, method_name):
+        return hasattr(type(self.driver.partner_id), method_name)
+
+    def test_create_company_delegates_to_partner(self):
+        if not self._partner_method_available("create_company"):
+            self.skipTest("create_company not available on res.partner")
+        self.driver.create_company()
+
+    def test_action_open_employees_delegates_to_partner(self):
+        if not self._partner_method_available("action_open_employees"):
+            self.skipTest("action_open_employees not available on res.partner")
+        action = self.driver.action_open_employees()
+        self.assertEqual(action.get("res_model"), "hr.employee")
+
+    def test_open_commercial_entity_delegates_to_partner(self):
+        if not self._partner_method_available("open_commercial_entity"):
+            self.skipTest("open_commercial_entity not available on res.partner")
+        action = self.driver.open_commercial_entity()
+        self.assertEqual(action.get("res_model"), "res.partner")
+
+    def test_blacklist_remove_delegates_to_partner(self):
+        if not self._partner_method_available("phone_action_blacklist_remove"):
+            self.skipTest("blacklist methods not available on res.partner")
+        self.driver.phone_action_blacklist_remove()
+        self.driver.mail_action_blacklist_remove()
+
+    def test_geo_localize_delegates_to_partner(self):
+        if not self._partner_method_available("geo_localize"):
+            self.skipTest("geo_localize not available on res.partner")
+        self.driver.geo_localize()
+
+    def test_action_view_partner_invoices_delegates_to_partner(self):
+        if not self._partner_method_available("action_view_partner_invoices"):
+            self.skipTest("action_view_partner_invoices not available")
+        action = self.driver.action_view_partner_invoices()
+        self.assertEqual(action.get("res_model"), "account.move")
+
+    def test_action_view_stock_serial_delegates_to_partner(self):
+        if not self._partner_method_available("action_view_stock_serial"):
+            self.skipTest("stock module is not installed")
+        action = self.driver.action_view_stock_serial()
+        self.assertEqual(action.get("res_model"), "stock.lot")
+
+    def test_action_view_purchase_orders_uses_partner_id(self):
+        try:
+            action = self.driver.action_view_purchase_orders()
+        except Exception:
+            self.skipTest("purchase module is not installed")
+        self.assertEqual(action.get("res_model"), "purchase.order")
+        self.assertEqual(
+            action.get("context", {}).get("search_default_partner_id"),
+            self.driver.partner_id.id,
+            "Purchase search should use the driver's partner id, not driver id",
+        )
+
+    def test_action_view_sale_orders_uses_partner_id(self):
+        try:
+            action = self.driver.action_view_sale_orders()
+        except Exception:
+            self.skipTest("sale module is not installed")
+        self.assertEqual(action.get("res_model"), "sale.order")
+        self.assertEqual(
+            action.get("context", {}).get("default_partner_id"),
+            self.driver.partner_id.id,
+            "Sale order should default to the driver's partner id, not driver id",
+        )

--- a/tms_account/tests/test_tms_account.py
+++ b/tms_account/tests/test_tms_account.py
@@ -122,6 +122,11 @@ class TestTMSOrderAccount(TestTMSAccountCommon):
         self.assertEqual(action["view_mode"], "list,form")
         self.assertEqual(action["res_model"], "account.move")
 
+    def test_driver_action_view_partner_invoices_delegates_to_partner(self):
+        driver = self.env["tms.driver"].create({"name": "Invoice Driver"})
+        action = driver.action_view_partner_invoices()
+        self.assertEqual(action["res_model"], "account.move")
+
 
 class TestAccountAnalyticLine(TestTMSAccountCommon):
     def test_analytic_line_updates_trip_totals(self):

--- a/tms_expense/tests/test_tms_driver.py
+++ b/tms_expense/tests/test_tms_driver.py
@@ -46,3 +46,9 @@ class TestTmsExpenseDriver(TransactionCase):
         employee = self.env["hr.employee"].search([("name", "=", driver.name)], limit=1)
         self.assertTrue(employee)
         self.assertEqual(employee.work_contact_id, driver.partner_id)
+
+    def test_action_open_employees_delegates_to_partner(self):
+        driver = self.env["tms.driver"].create({"name": "Employee Driver"})
+        action = driver.action_open_employees()
+        self.assertEqual(action["res_model"], "hr.employee")
+        self.assertEqual(action["view_mode"], "form")

--- a/tms_expense/tests/test_tms_driver.py
+++ b/tms_expense/tests/test_tms_driver.py
@@ -52,3 +52,8 @@ class TestTmsExpenseDriver(TransactionCase):
         action = driver.action_open_employees()
         self.assertEqual(action["res_model"], "hr.employee")
         self.assertEqual(action["view_mode"], "form")
+
+    def test_blacklist_remove_delegates_to_partner(self):
+        driver = self.env["tms.driver"].create({"name": "Blacklist Driver"})
+        driver.phone_action_blacklist_remove()
+        driver.mail_action_blacklist_remove()

--- a/tms_product/tests/test_fleet_vehicle.py
+++ b/tms_product/tests/test_fleet_vehicle.py
@@ -52,3 +52,8 @@ class TestFleetVehicle(BaseCommon):
         )
         self.assertEqual(transportable.vehicle_id, vehicle)
         self.assertEqual(transportable.measure_type, "unit")
+
+    def test_driver_action_view_stock_serial_delegates_to_partner(self):
+        driver = self.env["tms.driver"].create({"name": "Serial Driver"})
+        action = driver.action_view_stock_serial()
+        self.assertEqual(action["res_model"], "stock.lot")

--- a/tms_purchase/__manifest__.py
+++ b/tms_purchase/__manifest__.py
@@ -13,6 +13,7 @@
         "views/tms_order.xml",
         "views/purchase_order_views.xml",
         "views/fleet_vehicle_views.xml",
+        "views/tms_driver_views.xml",
     ],
     "demo": [
         "demo/tms_purchase_fleet_vehicle_model_brand.xml",

--- a/tms_purchase/models/__init__.py
+++ b/tms_purchase/models/__init__.py
@@ -2,3 +2,4 @@ from . import fleet_vehicle
 from . import purchase_order
 from . import tms_order
 from . import stock_move
+from . import tms_driver

--- a/tms_purchase/models/tms_driver.py
+++ b/tms_purchase/models/tms_driver.py
@@ -1,0 +1,19 @@
+# Copyright (C) 2026 VSL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class TmsDriver(models.Model):
+    _inherit = "tms.driver"
+
+    def action_view_purchase_orders(self):
+        self.ensure_one()
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "purchase.act_res_partner_2_purchase_order"
+        )
+        action["context"] = {
+            "search_default_partner_id": self.partner_id.id,
+            "default_partner_id": self.partner_id.id,
+        }
+        return action

--- a/tms_purchase/tests/test_tms_purchase.py
+++ b/tms_purchase/tests/test_tms_purchase.py
@@ -123,6 +123,26 @@ class TestTmsPurchase(BaseCommon):
         )
         self.assertEqual(purchase.trip_id, trip)
 
+    def test_driver_action_view_purchase_orders_uses_partner_id(self):
+        """The driver smart button must resolve the driver's partner id
+        (delegation inheritance), not the driver id."""
+        driver = self.env["tms.driver"].create({"name": "Driver Purchase"})
+        action = driver.action_view_purchase_orders()
+        self.assertEqual(action["res_model"], "purchase.order")
+        self.assertEqual(
+            action["context"]["search_default_partner_id"],
+            driver.partner_id.id,
+        )
+        self.assertEqual(
+            action["context"]["default_partner_id"],
+            driver.partner_id.id,
+        )
+        self.assertNotEqual(
+            action["context"]["search_default_partner_id"],
+            driver.id,
+            "Must use partner id, not driver id",
+        )
+
     def test_fleet_vehicle_action_view_order(self):
         action = self.vehicle.action_view_order()
         self.assertEqual(action["res_model"], "purchase.order")

--- a/tms_purchase/views/tms_driver_views.xml
+++ b/tms_purchase/views/tms_driver_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_tms_driver_form_inherit_purchase" model="ir.ui.view">
+        <field name="name">tms.driver.form.inherit.purchase</field>
+        <field name="model">tms.driver</field>
+        <field name="inherit_id" ref="tms.view_tms_driver_form_inherit" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//button[@name='%(purchase.act_res_partner_2_purchase_order)d']"
+                position="attributes"
+            >
+                <attribute name="type">object</attribute>
+                <attribute name="name">action_view_purchase_orders</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/tms_sale/__manifest__.py
+++ b/tms_sale/__manifest__.py
@@ -17,6 +17,7 @@
         "views/tms_order_views.xml",
         "views/product_template_views.xml",
         "views/seat_ticket_views.xml",
+        "views/tms_driver_views.xml",
     ],
     "demo": [
         "demo/fleet_vehicle.xml",

--- a/tms_sale/models/__init__.py
+++ b/tms_sale/models/__init__.py
@@ -3,3 +3,4 @@ from . import sale_order_line
 from . import sale_order
 from . import seat_ticket
 from . import tms_order
+from . import tms_driver

--- a/tms_sale/models/tms_driver.py
+++ b/tms_sale/models/tms_driver.py
@@ -1,0 +1,17 @@
+# Copyright (C) 2026 VSL
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class TmsDriver(models.Model):
+    _inherit = "tms.driver"
+
+    def action_view_sale_orders(self):
+        self.ensure_one()
+        action = self.env["ir.actions.act_window"]._for_xml_id(
+            "sale.act_res_partner_2_sale_order"
+        )
+        action["context"] = {"default_partner_id": self.partner_id.id}
+        action["domain"] = [("partner_id", "child_of", self.partner_id.id)]
+        return action

--- a/tms_sale/tests/test_sale_order.py
+++ b/tms_sale/tests/test_sale_order.py
@@ -253,3 +253,19 @@ class TestTmsSale(BaseCommon):
         order.sudo().write({"state": "sent"})
         draft_stage = self.env.ref("tms.tms_stage_order_draft")
         self.assertEqual(tms_order.stage_id, draft_stage)
+
+    def test_driver_action_view_sale_orders_uses_partner_id(self):
+        """The driver smart button must resolve the driver's partner id
+        (delegation inheritance), not the driver id."""
+        driver = self.env["tms.driver"].create({"name": "Driver Sale"})
+        action = driver.action_view_sale_orders()
+        self.assertEqual(action["res_model"], "sale.order")
+        self.assertEqual(
+            action["context"]["default_partner_id"],
+            driver.partner_id.id,
+        )
+        self.assertNotEqual(
+            action["context"]["default_partner_id"],
+            driver.id,
+            "Must use partner id, not driver id",
+        )

--- a/tms_sale/views/tms_driver_views.xml
+++ b/tms_sale/views/tms_driver_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_tms_driver_form_inherit_sale" model="ir.ui.view">
+        <field name="name">tms.driver.form.inherit.sale</field>
+        <field name="model">tms.driver</field>
+        <field name="inherit_id" ref="tms.view_tms_driver_form_inherit" />
+        <field name="arch" type="xml">
+            <xpath
+                expr="//button[@name='sale.act_res_partner_2_sale_order']"
+                position="attributes"
+            >
+                <attribute name="type">object</attribute>
+                <attribute name="name">action_view_sale_orders</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
## Problem

`tms.driver` uses delegation inheritance (`_inherits = {"res.partner": "partner_id"}`), meaning the **driver ID and partner ID are different** (e.g., driver 434 → partner 2278). Smart buttons inherited from the partner form (`base.view_partner_form`) passed `active_id` (the driver ID) where a `res.partner` ID was expected, causing crashes.

This affected multiple smart buttons on the driver form:
- **Satınalma (Purchase)**: `KeyNotFoundError` / `TypeError: Cannot read properties of undefined (reading 'display_name')` — the search model tried to resolve a non-existent partner
- **Çalışan (Employee)**: `AttributeError: 'super' object has no attribute 'action_open_employees'`
- **Satış (Sale)**: wrong `default_partner_id` when creating new orders (silent but incorrect)

## Root Cause

Two separate issues, both stemming from the delegation inheritance mismatch:

### 1. `type="action"` buttons — action context overrides button context

The Purchase and Sale smart buttons used `type="action"` triggering actions whose context contained `search_default_partner_id: active_id` (driver ID). Odoo's action service (`action_service.js`) gives the **action's own context precedence** over the button's context attribute (`makeContext([buttonContext, action.context])`), so the button context could not override it.

**Fix**: Changed buttons to `type="object"` calling Python methods (`action_view_purchase_orders`, `action_view_sale_orders`) that return the action with the correct `partner_id` from the delegation link.

### 2. Bridge methods used broken `super()` calls

Five bridge methods (`create_company`, `action_open_employees`, `open_commercial_entity`, `phone_action_blacklist_remove`, `mail_action_blacklist_remove`) plus `geo_localize` used `super().method()`. This fails because `_inherits` (delegation) does **not** place `res.partner` in the MRO.

**Fix**: Changed them to `self.partner_id.method()` delegation, matching the pattern already used by the working `schedule_meeting` method.

### 3. Missing bridge methods for view validation

Adding view inheritances on the driver form triggered Odoo 19's view validation, which checks that all `type="object"` buttons reference methods existing on the model. The `stock` module's `action_view_stock_serial` button (inherited from the partner form) had no corresponding method on `tms.driver`.

**Fix**: Added `action_view_stock_serial` and `action_view_partner_invoices` bridge methods following the same delegation pattern.

## Changes

| File | Module | Change |
|------|--------|--------|
| `tms/models/tms_driver.py` | tms | Fixed 6 broken `super()` → `self.partner_id` delegation; added 2 bridge methods (`action_view_stock_serial`, `action_view_partner_invoices`) |
| `tms_purchase/models/tms_driver.py` | tms_purchase | `action_view_purchase_orders` — rebuilt action with partner_id from delegation link |
| `tms_sale/models/tms_driver.py` | tms_sale | `action_view_sale_orders` — rebuilt action with partner_id from delegation link |
| `tms_purchase/views/tms_driver_views.xml` | tms_purchase | Purchase button → `type="object"` |
| `tms_sale/views/tms_driver_views.xml` | tms_sale | Sale button → `type="object"` |

## Verification

All methods tested via Odoo shell on a live driver record (id=434, partner_id=2278):

```
action_open_employees: OK -> hr.employee
action_view_purchase_orders: context={'search_default_partner_id': 2278, ...}
action_view_sale_orders: context={'default_partner_id': 2278}
create_company: OK
open_commercial_entity: OK
mail_action_blacklist_remove: OK
phone_action_blacklist_remove: OK
```

All 5 smart buttons on the driver form now work correctly.

## Tests

- `tms_purchase/tests/test_tms_purchase.py` — `test_driver_action_view_purchase_orders_uses_partner_id`
- `tms_sale/tests/test_sale_order.py` — `test_driver_action_view_sale_orders_uses_partner_id`
- `tms/tests/test_tms_driver.py` — delegation tests for base methods (`create_company`, `open_commercial_entity`, `geo_localize`)
- `tms_expense/tests/test_tms_driver.py` — `action_open_employees`, blacklist remove (hr/phone_validation)
- `tms_account/tests/test_tms_account.py` — `action_view_partner_invoices` (account)
- `tms_product/tests/test_fleet_vehicle.py` — `action_view_stock_serial` (stock)