### PR TITLE
[IMP] tms: track driver field changes and log creation in chatter

### DIFF
--- a/tms/__manifest__.py
+++ b/tms/__manifest__.py
@@ -12,6 +12,7 @@
     "data": [
         "data/ir_sequence_data.xml",
         "data/module_category.xml",
+        "data/mail_subtype.xml",
         "data/tms_stage.xml",
         "data/tms_team.xml",
         "data/uom_category.xml",

--- a/tms/__manifest__.py
+++ b/tms/__manifest__.py
@@ -8,7 +8,7 @@
     "category": "TMS",
     "author": "Open Source Integrators, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/stock-logistics-transport",
-    "depends": ["base", "uom", "fleet", "base_geolocalize"],
+    "depends": ["base", "mail", "uom", "fleet", "base_geolocalize"],
     "data": [
         "data/ir_sequence_data.xml",
         "data/module_category.xml",

--- a/tms/data/mail_subtype.xml
+++ b/tms/data/mail_subtype.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<odoo>
+<odoo noupdate="1">
     <record id="mt_driver_stage" model="mail.message.subtype">
         <field name="name">Stage</field>
         <field name="res_model">tms.driver</field>

--- a/tms/data/mail_subtype.xml
+++ b/tms/data/mail_subtype.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="mt_driver_stage" model="mail.message.subtype">
+        <field name="name">Stage</field>
+        <field name="res_model">tms.driver</field>
+        <field name="default" eval="False" />
+        <field name="description">Driver stage changed</field>
+    </record>
+</odoo>

--- a/tms/i18n/tms.pot
+++ b/tms/i18n/tms.pot
@@ -2699,11 +2699,10 @@ msgstr ""
 #. module: tms
 #. odoo-python
 #: code:addons/tms/models/tms_driver.py:0
-msgid "Driver Created"
+msgid "Driver created"
 msgstr ""
 
 #. module: tms
-#. odoo-python
-#: code:addons/tms/models/tms_driver.py:0
+#: model:mail.message.subtype,name:tms.mt_driver_stage
 msgid "Driver stage changed"
 msgstr ""

--- a/tms/i18n/tms.pot
+++ b/tms/i18n/tms.pot
@@ -2695,3 +2695,15 @@ msgstr ""
 #: model:uom.uom,name:tms.uom_mph
 msgid "mph"
 msgstr ""
+
+#. module: tms
+#. odoo-python
+#: code:addons/tms/models/tms_driver.py:0
+msgid "Driver Created"
+msgstr ""
+
+#. module: tms
+#. odoo-python
+#: code:addons/tms/models/tms_driver.py:0
+msgid "Driver stage changed"
+msgstr ""

--- a/tms/models/tms_driver.py
+++ b/tms/models/tms_driver.py
@@ -92,7 +92,7 @@ class TmsDriver(models.Model):
 
     def _creation_message(self):
         self.ensure_one()
-        return self.env._("Driver Created")
+        return self.env._("Driver created")
 
     def _track_subtype(self, init_values):
         self.ensure_one()

--- a/tms/models/tms_driver.py
+++ b/tms/models/tms_driver.py
@@ -25,15 +25,15 @@ class TmsDriver(models.Model):
     # ------------------------------
 
     # Driver - Flags
-    is_external = fields.Boolean(string="External Driver")
-    is_training = fields.Boolean(string="In Training")
-    is_active = fields.Boolean(default=True)
+    is_external = fields.Boolean(string="External Driver", tracking=True)
+    is_training = fields.Boolean(string="In Training", tracking=True)
+    is_active = fields.Boolean(default=True, tracking=True)
 
     # Driver - Relations
     vehicles_ids = fields.One2many("fleet.vehicle", "driver_id")
     trips_ids = fields.One2many("tms.order", "driver_id")
 
-    tms_team_id = fields.Many2one("tms.team")
+    tms_team_id = fields.Many2one("tms.team", tracking=True)
     crew_ids = fields.Many2many(
         "tms.crew",
         "tms_crew_drivers_rel",
@@ -44,6 +44,7 @@ class TmsDriver(models.Model):
         string="Stage",
         index=True,
         copy=False,
+        tracking=True,
         default=lambda self: self._default_stage_id(),
         group_expand="_read_group_stage_ids",
     )
@@ -59,19 +60,19 @@ class TmsDriver(models.Model):
 
     # TODO: ADD A LICENCE MODEL
     # Terrestrial - Licenses
-    driver_license_number = fields.Char()
+    driver_license_number = fields.Char(tracking=True)
     driver_license_type = fields.Selection(
-        string="License type", selection=DRIVER_LICENSE_TYPES
+        string="License type", selection=DRIVER_LICENSE_TYPES, tracking=True
     )
-    driver_license_expiration_date = fields.Date()
+    driver_license_expiration_date = fields.Date(tracking=True)
     driver_license_file = fields.Binary()
 
     # Terrestrial - Experience
-    distance_traveled = fields.Integer()
+    distance_traveled = fields.Integer(tracking=True)
     distance_traveled_uom = fields.Selection(
-        selection=[("km", "km"), ("mi", "mi")], default="km"
+        selection=[("km", "km"), ("mi", "mi")], default="km", tracking=True
     )
-    driving_experience_years = fields.Integer()
+    driving_experience_years = fields.Integer(tracking=True)
 
     @api.model
     def _read_group_stage_ids(self, stages, domain, order=None):
@@ -88,6 +89,16 @@ class TmsDriver(models.Model):
         )
         if stage:
             return stage.id
+
+    def _creation_message(self):
+        self.ensure_one()
+        return self.env._("Driver Created")
+
+    def _track_subtype(self, init_values):
+        self.ensure_one()
+        if "stage_id" in init_values:
+            return self.env.ref("tms.mt_driver_stage")
+        return super()._track_subtype(init_values)
 
     # Inherited actions from res_partner
 

--- a/tms/tests/test_tms_driver.py
+++ b/tms/tests/test_tms_driver.py
@@ -99,18 +99,17 @@ class TestTmsDriver(TransactionCase):
         self.driver.geo_localize()
 
     def test_creation_message(self):
-        self.assertEqual(self.driver._creation_message(), "Driver Created")
+        self.assertEqual(self.driver._creation_message(), "Driver created")
 
     def test_track_subtype_on_stage_change(self):
-        self.driver._track_subtype({"stage_id": self.driver.stage_id.id})
         subtype = self.env.ref("tms.mt_driver_stage")
         self.assertEqual(
-            self.driver._track_subtype({"stage_id": 1}),
+            self.driver._track_subtype({"stage_id": self.stage.id}),
             subtype,
         )
 
     def test_track_subtype_returns_false_for_other_fields(self):
-        self.assertFalse(self.driver._track_subtype({"name": "X"}))
+        self.assertFalse(self.driver._track_subtype({"driver_type": "terrestrial"}))
 
     def test_driver_creation_logs_message_in_chatter(self):
         self.env.cr.precommit.run()
@@ -118,7 +117,7 @@ class TestTmsDriver(TransactionCase):
         self.env.cr.precommit.run()
         messages = new_driver.message_ids
         self.assertTrue(messages)
-        self.assertIn("Driver Created", messages.body)
+        self.assertIn("Driver created", messages[0].body)
 
     def test_stage_change_logs_subtype(self):
         new_stage = self.env["tms.stage"].create(
@@ -143,5 +142,9 @@ class TestTmsDriver(TransactionCase):
         self.env.cr.precommit.run()
         new_messages = self.driver.message_ids - before
         self.assertTrue(new_messages)
-        tracked_fields = new_messages.tracking_value_ids.field_id.name
+        tracked_fields = {
+            field_name
+            for message in new_messages
+            for field_name in message.tracking_value_ids.field_id.mapped("name")
+        }
         self.assertIn("is_external", tracked_fields)

--- a/tms/tests/test_tms_driver.py
+++ b/tms/tests/test_tms_driver.py
@@ -97,3 +97,51 @@ class TestTmsDriver(TransactionCase):
 
     def test_geo_localize_delegates_to_partner(self):
         self.driver.geo_localize()
+
+    def test_creation_message(self):
+        self.assertEqual(self.driver._creation_message(), "Driver Created")
+
+    def test_track_subtype_on_stage_change(self):
+        self.driver._track_subtype({"stage_id": self.driver.stage_id.id})
+        subtype = self.env.ref("tms.mt_driver_stage")
+        self.assertEqual(
+            self.driver._track_subtype({"stage_id": 1}),
+            subtype,
+        )
+
+    def test_track_subtype_returns_false_for_other_fields(self):
+        self.assertFalse(self.driver._track_subtype({"name": "X"}))
+
+    def test_driver_creation_logs_message_in_chatter(self):
+        self.env.cr.precommit.run()
+        new_driver = self.env["tms.driver"].create({"name": "Chatter Driver"})
+        self.env.cr.precommit.run()
+        messages = new_driver.message_ids
+        self.assertTrue(messages)
+        self.assertIn("Driver Created", messages.body)
+
+    def test_stage_change_logs_subtype(self):
+        new_stage = self.env["tms.stage"].create(
+            {
+                "name": "New Stage",
+                "stage_type": "driver",
+                "sequence": 2,
+            }
+        )
+        self.env.cr.precommit.run()
+        self.driver.write({"stage_id": new_stage.id})
+        self.env.cr.precommit.run()
+        subtype_messages = self.driver.message_ids.filtered(
+            lambda m: m.subtype_id == self.env.ref("tms.mt_driver_stage")
+        )
+        self.assertTrue(subtype_messages)
+
+    def test_tracked_field_change_logs_message(self):
+        self.env.cr.precommit.run()
+        before = self.driver.message_ids
+        self.driver.write({"is_external": False})
+        self.env.cr.precommit.run()
+        new_messages = self.driver.message_ids - before
+        self.assertTrue(new_messages)
+        tracked_fields = new_messages.tracking_value_ids.field_id.name
+        self.assertIn("is_external", tracked_fields)


### PR DESCRIPTION
## Summary

Improve driver form chatter: field changes are now logged and driver creation posts a message.

## Changes

- **`tms/models/tms_driver.py`**
  - Add `tracking=True` to key driver fields (`is_external`, `is_training`, `is_active`, `tms_team_id`, `stage_id`, `driver_license_number`, `driver_license_type`, `driver_license_expiration_date`, `distance_traveled`, `distance_traveled_uom`, `driving_experience_years`) so edits show in the chatter
  - Add `_creation_message()` — posts "Driver Created" when a driver is created
  - Add `_track_subtype()` — posts a dedicated subtype when the stage changes
- **`tms/data/mail_subtype.xml`** — new `mt_driver_stage` `mail.message.subtype`
- **`tms/__manifest__.py`** — register the new data file
- **`tms/i18n/tms.pot`** — add "Driver Created" / "Driver stage changed" strings

## Scope

This PR is **scoped to the driver chatter feature only** (4 files in `tms/`). It does not include the driver smart-button delegation fixes (PR #237) or the `tms_document` module (PR #234), which were split out per review.